### PR TITLE
[seta-react] Optimize primereact imports & add linting rule

### DIFF
--- a/seta-react/.eslintrc.json
+++ b/seta-react/.eslintrc.json
@@ -146,6 +146,18 @@
       "warn",
       { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
     ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [{
+          "name": "primereact",
+          "message": "Please import each component from 'primereact/<component>'."
+        }],
+        "patterns": [
+          "!primereact/*"
+        ]
+      }
+    ],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "space-before-blocks": "error",

--- a/seta-react/src/components/DialogButton/DialogButton.tsx
+++ b/seta-react/src/components/DialogButton/DialogButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { Dialog } from 'primereact'
 import { Button } from 'primereact/button'
+import { Dialog } from 'primereact/dialog'
 
 import './style.css'
 import { CorpusService } from '../../services/corpus/corpus.service'

--- a/seta-react/src/components/DocumentList/DocumentList.tsx
+++ b/seta-react/src/components/DocumentList/DocumentList.tsx
@@ -1,15 +1,22 @@
 import { useState, useEffect, useRef } from 'react'
-import { DataTable, MultiSelect } from 'primereact'
 import { Column } from 'primereact/column'
+import type { DataTableExpandedRows } from 'primereact/datatable'
+import { DataTable } from 'primereact/datatable'
+import { MultiSelect } from 'primereact/multiselect'
 import { ProgressBar } from 'primereact/progressbar'
 import './style.css'
 
 const DocumentList = list => {
   const isMounted = useRef(false)
   const [items, setItems] = useState<any>([])
-  const [expandedRows, setExpandedRows] = useState(null)
   const [basicFirst, setBasicFirst] = useState(0)
   const [basicRows, setBasicRows] = useState(10)
+
+  // DataTable.onRowToggle sends this type (including any[]) as e.data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [expandedRows, setExpandedRows] = useState<any[] | DataTableExpandedRows | undefined>(
+    undefined
+  )
 
   useEffect(() => {
     const documentsList = list.documents.data

--- a/seta-react/src/components/FileUploads/FileUploads.tsx
+++ b/seta-react/src/components/FileUploads/FileUploads.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from 'react'
-import { FileUpload, ProgressBar, Tag } from 'primereact'
 import { Button } from 'primereact/button'
+import { FileUpload } from 'primereact/fileupload'
+import { ProgressBar } from 'primereact/progressbar'
+import { Tag } from 'primereact/tag'
 
 export const FileUploads = ({ onChange }) => {
   const [totalSize, setTotalSize] = useState(0)

--- a/seta-react/src/components/TabMenu/TabMenu.tsx
+++ b/seta-react/src/components/TabMenu/TabMenu.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { TabView, TabPanel } from 'primereact'
+import { TabView, TabPanel } from 'primereact/tabview'
 
 import DocumentList from '../DocumentList'
 import TabMenuFilters from '../TabMenuFilters'

--- a/seta-react/src/components/TabMenuFilters/TabMenuFilters.tsx
+++ b/seta-react/src/components/TabMenuFilters/TabMenuFilters.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { TabView, TabPanel } from 'primereact'
+import { TabView, TabPanel } from 'primereact/tabview'
 
 import PostSearch from '../PostSearch'
 import SearchType from '../SearchType'

--- a/seta-react/src/components/TextareaInput/TextareaInput.tsx
+++ b/seta-react/src/components/TextareaInput/TextareaInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { InputTextarea } from 'primereact'
+import { InputTextarea } from 'primereact/inputtextarea'
 import './style.css'
 
 const TextareaInput = ({ onChange }) => {

--- a/seta-react/src/pages/ProfilePage/ProfilePage.tsx
+++ b/seta-react/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { InputText } from 'primereact'
 import { Button } from 'primereact/button'
+import { InputText } from 'primereact/inputtext'
 import { InputTextarea } from 'primereact/inputtextarea'
 
 import { defaultNoPublicKeyMessage } from '../../common/constants'


### PR DESCRIPTION
## Description

Optimized all `primereact` imports to target each component's module, reducing as a result the bundle size with around 40%.

Also, introduced a new ESLint rule to enforce all PrimeReact component imports from `primereact/<component>`.

## How to test

There are no functional changes introduced in this PR, just make sure the app runs as expected.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/127730071/229415441-0977e15d-a57e-4279-899f-fb5dad16a937.png)|![image](https://user-images.githubusercontent.com/127730071/229415506-b6aa0993-c73e-4c85-b0ef-8bdf918a5833.png)|
|`JS:  466.32 kB`<br>`CSS:  82.06 kB`|`JS:  269.79 kB  // ~ 42% less`<br>`CSS:  50.37 kB  // ~ 38% less`|



