### PR TITLE
[seta-react] Update document results UX & taxonomy handling

### DIFF
--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Anchor, Flex, Progress, Text, Tooltip, clsx } from '@mantine/core'
+import { Anchor, Flex, Progress, Text, clsx } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { FaChevronDown } from 'react-icons/fa'
 
@@ -29,34 +29,31 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
   const [titleHl, abstractHl] = useHighlight(queryTerms, title, abstract)
 
   const chevronClass = clsx({ open: detailsOpen })
+  const openClass = clsx({ open: detailsOpen })
 
   const hasDetails = !!taxonomy?.length || !!chunk_text
 
   const toggleIcon = hasDetails && (
-    <div css={S.chevron} className={chevronClass} onClick={toggle}>
+    <div css={S.chevron} className={chevronClass}>
       <FaChevronDown />
     </div>
   )
 
   return (
-    <div>
-      <div css={S.header}>
-        <Tooltip label={`Score: ${score}`}>
-          <Progress size="xl" value={score} color="teal" />
-        </Tooltip>
+    <div css={S.root} className={openClass}>
+      <div css={S.header} data-details={hasDetails} onClick={toggle}>
+        <Progress size="xl" value={score} color="teal" />
 
-        <Tooltip label={`"${title}"`} position="top-start">
-          <div css={S.title} data-details={hasDetails} onClick={toggle}>
-            <Text fz="xl" fw={600} truncate="end">
-              {titleHl}
-            </Text>
-          </div>
-        </Tooltip>
+        <div css={S.title}>
+          <Text fz="xl" fw={600} truncate={detailsOpen ? undefined : 'end'}>
+            {titleHl}
+          </Text>
+        </div>
 
         {toggleIcon}
       </div>
 
-      <Flex direction="column" gap="xs" css={S.info}>
+      <Flex direction="column" gap="xs" data-info css={S.info}>
         <div>{abstractHl}</div>
 
         <div css={S.path}>{path}</div>

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
@@ -14,14 +14,16 @@ type Props = ClassNameProp & {
 }
 
 const DocumentDetails = ({ className, open, taxonomy, chunkText, queryTerms }: Props) => {
-  if (!taxonomy && !chunkText) {
+  const hasTaxonomy = !!taxonomy?.length
+
+  if (!hasTaxonomy && !chunkText) {
     return null
   }
 
   return (
     <Collapse className={className} in={open}>
       <Flex gap="md">
-        {taxonomy && <TaxonomyTree taxonomy={taxonomy} />}
+        {hasTaxonomy && <TaxonomyTree taxonomy={taxonomy} />}
         {chunkText && <ChunkPreview text={chunkText} queryTerms={queryTerms} />}
       </Flex>
     </Collapse>

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/TaxonomyTree/TaxonomyNode.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/TaxonomyTree/TaxonomyNode.tsx
@@ -1,24 +1,23 @@
 import { clsx } from '@mantine/core'
 
 import type { ClassNameProp } from '~/types/children-props'
+import type { Taxonomy } from '~/types/search/documents'
 
 import * as S from './styles'
 
-import type { TaxonomyTreeNode } from '../../utils/taxonomy-tree'
-
 type Props = ClassNameProp & {
-  node: TaxonomyTreeNode
+  taxonomy: Taxonomy
 }
 
-const TaxonomyNode = ({ className, node }: Props) => {
-  const { children, label } = node
+const TaxonomyNode = ({ className, taxonomy }: Props) => {
+  const { subcategories, label } = taxonomy
 
-  const nodeClass = clsx(className, { leaf: !children.length })
+  const nodeClass = clsx(className, { leaf: !subcategories.length })
 
-  const childrenContainer = !!children.length && (
+  const childrenContainer = !!subcategories.length && (
     <div>
-      {node.children.map(child => (
-        <TaxonomyNode key={child.code} node={child} />
+      {subcategories.map(child => (
+        <TaxonomyNode key={child.code} taxonomy={child} />
       ))}
     </div>
   )

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/TaxonomyTree/TaxonomyTree.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/TaxonomyTree/TaxonomyTree.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Text } from '@mantine/core'
 
 import type { Taxonomy } from '~/types/search/documents'
@@ -6,22 +5,18 @@ import type { Taxonomy } from '~/types/search/documents'
 import * as S from './styles'
 import TaxonomyNode from './TaxonomyNode'
 
-import { buildTaxonomyTree } from '../../utils/taxonomy-tree'
-
 type Props = {
   taxonomy: Taxonomy[]
 }
 
 const TaxonomyTree = ({ taxonomy }: Props) => {
-  const tree = useMemo(() => buildTaxonomyTree(taxonomy), [taxonomy])
-
   return (
     <S.Container>
       <Text fz="lg" fw={600} color="gray.8" mb="sm">
         Taxonomy
       </Text>
-      {tree.map(node => (
-        <TaxonomyNode key={node.code} node={node} css={S.rootNode} />
+      {taxonomy.map(node => (
+        <TaxonomyNode key={node.code} taxonomy={node} css={S.rootNode} />
       ))}
     </S.Container>
   )

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
@@ -10,6 +10,27 @@ const fill = keyframes({
   }
 })
 
+export const root: ThemedCSS = theme => css`
+  transition: padding-top 200ms ${theme.transitionTimingFunction},
+    padding-bottom 200ms ${theme.transitionTimingFunction};
+
+  &.open {
+    margin: 0 -${theme.spacing.sm};
+    padding: ${theme.spacing.sm};
+    border-radius: ${theme.radius.sm};
+    border: 1px solid ${theme.colors.gray[3]};
+
+    & [data-details='true'] {
+      border-color: transparent !important;
+      transition: none !important;
+    }
+
+    & [data-info] {
+      margin-top: ${theme.spacing.sm};
+    }
+  }
+`
+
 export const header: ThemedCSS = theme => css`
   display: grid;
   grid-template-columns: ${PROGRESS_WIDTH} 1fr auto;
@@ -18,6 +39,23 @@ export const header: ThemedCSS = theme => css`
 
   & .seta-Progress-bar {
     animation: ${fill} 300ms ease;
+  }
+
+  &[data-details='true'] {
+    cursor: pointer;
+    margin: 0 -${theme.spacing.sm};
+    padding: 0 ${theme.spacing.sm};
+    border-radius: ${theme.radius.sm};
+    border: 1px solid transparent;
+    transition: border-color 200ms ${theme.transitionTimingFunction};
+
+    &:hover {
+      border-color: ${theme.colors.gray[3]};
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
   }
 `
 
@@ -28,7 +66,6 @@ export const chevron: ThemedCSS = theme => css`
   color: ${theme.colors.gray[7]};
   transition: transform 200ms ${theme.transitionTimingFunction};
   animation: fill 300ms ease;
-  cursor: pointer;
 
   &.open {
     transform: rotate(180deg);
@@ -38,10 +75,6 @@ export const chevron: ThemedCSS = theme => css`
 export const title: ThemedCSS = theme => css`
   overflow: hidden;
   color: ${theme.colors.dark[5]};
-
-  &[data-details='true'] {
-    cursor: pointer;
-  }
 `
 
 const contentMarginLeft: ThemedCSS = theme => css`
@@ -51,6 +84,7 @@ const contentMarginLeft: ThemedCSS = theme => css`
 export const info: ThemedCSS = theme => css`
   color: ${theme.colors.gray[6]};
   ${contentMarginLeft(theme)};
+  transition: margin-top 200ms ${theme.transitionTimingFunction};
 `
 
 export const path: ThemedCSS = theme => css`

--- a/seta-react/src/types/search/documents.ts
+++ b/seta-react/src/types/search/documents.ts
@@ -3,10 +3,10 @@ export type Taxonomy = {
   code: string
   label: string
   longLabel: string
-  name: string
   name_in_path: string
   validated: 'true' | 'false'
   version: string
+  subcategories: Taxonomy[]
 }
 
 export type Document = {


### PR DESCRIPTION
## Description

This PR introduces UX improvements for the documents search results list and adjusts the taxonomy handling to match the API updates.

## How to test
- Make sure you have documents indexed in ES
- Go to http://localhost/search-new or click on the Search New [WIP] menu link
- Type a few terms in the search box and press the Search button
- The list of documents should appear
- Move your mouse cursor over the header/title of a document in the list
  - Verify that the header appears "interactable" to the user
- Click on the document header/title to expand its details
  - Verify that expanded documents are easily identifiable
  - Verify that the `Taxonomy` section, when present, is correctly represented in the UI