### PR TITLE
[seta-react] Fix console log removal in development

### DIFF
--- a/seta-react/src/libs/axios-logger.ts
+++ b/seta-react/src/libs/axios-logger.ts
@@ -1,10 +1,11 @@
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 
-// We're using console.log() to log the request and response in the browser console.
-// eslint-disable-next-line no-console
-const log = console.log
-
 const dontLog = !import.meta.env.DEV || import.meta.env.VITE_API_DISABLE_LOGGER === 'true'
+
+// We're using console.log() to log the request and response in the browser console.
+// During build, the console.log() statements will be removed by esbuild.
+// eslint-disable-next-line no-console
+const log = (console.log && console.log.bind(console)) || undefined
 
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
@@ -43,7 +44,7 @@ export const logRequest = (config: AxiosRequestConfig) => {
   const { url, method } = config
   const methodValue = method?.toUpperCase() ?? 'GET'
 
-  log(`%c${methodValue} %c${url}`, color('gray3'), color('gray2'))
+  log?.(`%c${methodValue} %c${url}`, color('gray3'), color('gray2'))
 }
 
 export const logResponse = (response: AxiosResponse) => {
@@ -60,7 +61,7 @@ export const logResponse = (response: AxiosResponse) => {
   const roundedSeconds = Math.round(duration / 10) / 100
   const durationFormatted = duration >= 1000 ? `${roundedSeconds}s` : `${duration}ms`
 
-  log(
+  log?.(
     `%c${methodValue} %c${url} %c${status} ${statusText} %c${durationFormatted}  `,
     color(methodValue),
     color('gray'),

--- a/seta-react/vite.config.js
+++ b/seta-react/vite.config.js
@@ -5,8 +5,6 @@ import checker from 'vite-plugin-checker'
 import svgrPlugin from 'vite-plugin-svgr'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
 
-const isBuild = process.env.NODE_ENV === 'production'
-
 // Checker plugin options for production build
 /** @type {Parameters<import('vite-plugin-checker').checker>[0]} */
 const checkerProd = {
@@ -25,32 +23,35 @@ const checkerDev = {
   }
 }
 
-export default defineConfig({
-  plugins: [
-    react(),
-    viteTsconfigPaths(),
-    svgrPlugin(),
+export default defineConfig(({ mode }) => {
+  const isBuild = mode === 'production'
 
-    checker(isBuild ? checkerProd : checkerDev)
-  ],
+  return {
+    plugins: [
+      react(),
+      viteTsconfigPaths(),
+      svgrPlugin(),
 
-  server: {
-    host: 'localhost',
-    port: 3000,
-    // Uncomment the line below to open the page automatically when running the server locally
-    // open: 'http://localhost:3000/'
+      checker(isBuild ? checkerProd : checkerDev)
+    ],
 
-    strictPort: true,
-    hmr: {
-      clientPort: 3000
+    server: {
+      host: 'localhost',
+      port: 3000,
+      // Uncomment the line below to open the page automatically when running the server locally
+      // open: 'http://localhost:3000/'
+      strictPort: true,
+      hmr: {
+        clientPort: 3000
+      }
+    },
+
+    build: {
+      outDir: 'build'
+    },
+
+    esbuild: {
+      drop: isBuild ? ['console', 'debugger'] : []
     }
-  },
-
-  build: {
-    outDir: 'build'
-  },
-
-  esbuild: {
-    drop: ['console', 'debugger']
   }
 })


### PR DESCRIPTION
## Description

Fixes the incorrect removal of `console` and `debugger` statements during development.
Now, they should only be dropped for the production build.

## How to test
- Add a `console.log` statement in any component
- Verify that it's logged in the browser's console