### PR TITLE
[seta-react] React auth improvements

### DIFF
--- a/seta-react/src/App.tsx
+++ b/seta-react/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import { queryClientOptions } from '~/config/query-client-config'
+import { UserProvider } from '~/contexts/user-context'
 
 import AppRouter from './components/AppRouter'
 import { emotionCache, theme } from './styles'
@@ -14,7 +15,9 @@ const App = () => {
   return (
     <MantineProvider withGlobalStyles withNormalizeCSS emotionCache={emotionCache} theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <AppRouter />
+        <UserProvider>
+          <AppRouter />
+        </UserProvider>
 
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/seta-react/src/api/auth.ts
+++ b/seta-react/src/api/auth.ts
@@ -1,0 +1,38 @@
+import type { UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import type { AxiosRequestConfig } from 'axios'
+
+import api from '~/api'
+import { environment } from '~/environments/environment'
+import type { User } from '~/types/user'
+
+const BASE_URL = environment.baseUrl
+const USER_INFO_API_PATH = '/me/user-info'
+const REFRESH_TOKEN_API_PATH = '/refresh'
+
+const apiConfig: AxiosRequestConfig = {
+  baseURL: BASE_URL
+}
+
+export type UserInfoResponse = User
+
+const getUserInfo = async (): Promise<UserInfoResponse> => {
+  const { data } = await api.get<UserInfoResponse>(USER_INFO_API_PATH, apiConfig)
+
+  return data
+}
+
+type UseUserInfoOptions = Pick<
+  UseQueryOptions<UserInfoResponse>,
+  'enabled' | 'onSuccess' | 'onError' | 'onSettled' | 'notifyOnChangeProps'
+>
+
+export const useUserInfo = (options: UseUserInfoOptions) =>
+  useQuery({
+    ...options,
+    queryKey: ['user-info'],
+    queryFn: getUserInfo,
+    cacheTime: 0
+  })
+
+export const refreshToken = async () => api.get(REFRESH_TOKEN_API_PATH, apiConfig)

--- a/seta-react/src/components/AppRouter/AppRouter.tsx
+++ b/seta-react/src/components/AppRouter/AppRouter.tsx
@@ -35,7 +35,6 @@ import HomePage from '../../pages/HomePage'
 import LoginPage from '../../pages/LoginPage'
 import NotFoundPage from '../../pages/NotFoundPage'
 import ProfilePage from '../../pages/ProfilePage'
-import SearchPage from '../../pages/SearchPage/SearchPage'
 import SearchPageNew from '../../pages/SearchPageNew'
 
 const ROOT_PATH = '/'
@@ -50,21 +49,14 @@ const routes = createRoutesFromElements(
     <Route path="home" element={<Navigate to={ROOT_PATH} />} />
 
     <Route
-      path="search-new"
+      path="search"
       element={
         <RequireAuth>
           <SearchPageNew />
         </RequireAuth>
       }
     />
-    <Route
-      path="search"
-      element={
-        <RequireAuth>
-          <SearchPage />
-        </RequireAuth>
-      }
-    />
+
     <Route
       path="profile"
       element={

--- a/seta-react/src/components/AppRouter/components/RequireAuth.tsx
+++ b/seta-react/src/components/AppRouter/components/RequireAuth.tsx
@@ -1,16 +1,25 @@
+import { Flex, Loader } from '@mantine/core'
 import { Navigate } from 'react-router-dom'
 
-import storageService from '../../../services/storage.service'
+import { useCurrentUser } from '~/contexts/user-context'
+
 import type { ChildrenProp } from '../../../types/children-props'
 
 // TODO: Get this from an environment variable
 const AUTH_PATH = '/login'
 
 const RequireAuth = ({ children }: ChildrenProp) => {
-  // FIXME: StorageService isn't really a secure way to identify if a user is logged in
-  const isAuthenticated = storageService.isLoggedIn()
+  const { user, isLoading } = useCurrentUser()
 
-  return isAuthenticated ? children : <Navigate to={AUTH_PATH} />
+  if (isLoading) {
+    return (
+      <Flex align="center" justify="center" m="auto" h="100vh">
+        <Loader size="xl" />
+      </Flex>
+    )
+  }
+
+  return user ? children : <Navigate to={AUTH_PATH} />
 }
 
 export default RequireAuth

--- a/seta-react/src/components/Header/Header.tsx
+++ b/seta-react/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import type { MouseEventHandler } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { Button } from 'primereact/button'
 import { InputText } from 'primereact/inputtext'
 import { Menubar } from 'primereact/menubar'
@@ -7,8 +7,9 @@ import type { MenuItem, MenuItemTemplateType } from 'primereact/menuitem'
 import { TieredMenu } from 'primereact/tieredmenu'
 import { Link, NavLink } from 'react-router-dom'
 
+import { useCurrentUser } from '~/contexts/user-context'
+
 import authentificationService from '../../services/authentification.service'
-import storageService from '../../services/storage.service'
 
 import './style.css'
 
@@ -51,27 +52,16 @@ const navEnd = (
 
 const Header = () => {
   const dashboard = useRef<TieredMenu>(null)
-  const [authenticated, setAuthenticated] = useState(false)
 
-  useEffect(() => {
-    const loggedIn = storageService.isLoggedIn()
+  const { user } = useCurrentUser()
 
-    // TODO: Move the current user or authentication checks to a context/hook
-    setAuthenticated(loggedIn)
-  }, [])
+  const authenticated = !!user
 
   const navMenu: MenuItem[] = [
     {
       label: 'Search',
       className: 'seta-item',
       url: '/search',
-      visible: authenticated,
-      template: navLinkTemplate
-    },
-    {
-      label: 'Search New [WIP]',
-      className: 'seta-item',
-      url: '/search-new',
       visible: authenticated,
       template: navLinkTemplate
     },

--- a/seta-react/src/contexts/user-context.tsx
+++ b/seta-react/src/contexts/user-context.tsx
@@ -1,0 +1,82 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { isAxiosError } from 'axios'
+
+import { useUserInfo } from '~/api/auth'
+import type { ChildrenProp } from '~/types/children-props'
+import type { User } from '~/types/user'
+
+type UserContextProps = {
+  user: User | null
+  isLoading: boolean
+  verify: () => void
+}
+
+const UserContext = createContext<UserContextProps | undefined>(undefined)
+
+export const UserProvider = ({ children }: ChildrenProp) => {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const prevUserRef = useRef<User | null>(null)
+
+  const { refetch: verifyUser } = useUserInfo({
+    enabled: false
+  })
+
+  useEffect(() => {
+    if (user) {
+      return
+    }
+
+    const getUser = async () => {
+      setLoading(true)
+
+      try {
+        const { data } = await verifyUser()
+
+        if (!data) {
+          setLoading(false)
+          setUser(null)
+
+          return
+        }
+
+        setUser(data)
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 401) {
+          setUser(null)
+        }
+
+        setLoading(false)
+      }
+    }
+
+    getUser()
+  }, [user, verifyUser])
+
+  // Delay the loading state to allow the user to be set first
+  useEffect(() => {
+    if (user?.username !== prevUserRef.current?.username) {
+      prevUserRef.current = user
+      setLoading(false)
+    }
+  }, [user])
+
+  const value: UserContextProps = {
+    user,
+    isLoading: loading,
+    verify: verifyUser
+  }
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+}
+
+export const useCurrentUser = () => {
+  const context = useContext(UserContext)
+
+  if (context === undefined) {
+    throw new Error('useCurrentUser must be used within a UserProvider')
+  }
+
+  return context
+}

--- a/seta-react/src/layouts/AppLayout/AppLayout.tsx
+++ b/seta-react/src/layouts/AppLayout/AppLayout.tsx
@@ -4,18 +4,16 @@ import { Outlet } from 'react-router-dom'
 import Footer from '../../components/Footer'
 import Header from '../../components/Header'
 
-const AppLayout = () => {
-  return (
-    <Flex direction="column" className="min-h-screen">
-      <Header />
+const AppLayout = () => (
+  <Flex direction="column" className="min-h-screen">
+    <Header />
 
-      <Flex direction="column" mih="600px" sx={{ flexGrow: 1 }}>
-        <Outlet />
-      </Flex>
-
-      <Footer />
+    <Flex direction="column" mih="600px" sx={{ flexGrow: 1 }}>
+      <Outlet />
     </Flex>
-  )
-}
+
+    <Footer />
+  </Flex>
+)
 
 export default AppLayout

--- a/seta-react/src/libs/axios-error-interceptor.ts
+++ b/seta-react/src/libs/axios-error-interceptor.ts
@@ -1,0 +1,23 @@
+import type { AxiosError } from 'axios'
+
+const errorInterceptor = (error: AxiosError) => {
+  if (!error.response) {
+    return Promise.reject(error)
+  }
+
+  const { status } = error.response
+
+  // Redirect to login everything but '/me/user-info'
+
+  if (error.config?.url?.includes('/me/user-info')) {
+    return Promise.reject(error)
+  }
+
+  if (status === 401) {
+    window.location.href = '/login?redirect=' + window.location.pathname
+  }
+
+  return Promise.reject(error)
+}
+
+export default errorInterceptor

--- a/seta-react/src/libs/axios.ts
+++ b/seta-react/src/libs/axios.ts
@@ -2,6 +2,7 @@ import type { AxiosRequestConfig } from 'axios'
 import axios from 'axios'
 
 import { environment } from '~/environments/environment'
+import errorInterceptor from '~/libs/axios-error-interceptor'
 import { logResponse } from '~/libs/axios-logger'
 import { paramsSerializer } from '~/utils/api-utils'
 
@@ -24,6 +25,6 @@ instance.interceptors.response.use(response => {
   logResponse(response)
 
   return response
-})
+}, errorInterceptor)
 
 export default instance

--- a/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/OntologyHeader/OntologyHeader.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/OntologyHeader/OntologyHeader.tsx
@@ -1,6 +1,5 @@
 import type { ActionIconProps, ChipProps, SelectItem } from '@mantine/core'
-import { Text, Select, Chip, ActionIcon, Flex, Tooltip } from '@mantine/core'
-import { IconWand } from '@tabler/icons-react'
+import { Text, Select, Chip, Flex, Tooltip } from '@mantine/core'
 
 import { useSearch } from '~/pages/SearchPageNew/contexts/search-context'
 import { useTermsSelection } from '~/pages/SearchPageNew/contexts/terms-selection-context'
@@ -84,20 +83,20 @@ const OntologyHeader = ({
     </Text>
   )
 
-  const enrichButton = hasToken && (
-    <Tooltip label="Enrich query automatically">
-      <ActionIcon size="lg" radius="md" onClick={onEnrichToggle} {...enrichedProps}>
-        <IconWand />
-      </ActionIcon>
-    </Tooltip>
-  )
+  // const enrichButton = hasToken && (
+  //   <Tooltip label="Enrich query automatically">
+  //     <ActionIcon size="lg" radius="md" onClick={onEnrichToggle} {...enrichedProps}>
+  //       <IconWand />
+  //     </ActionIcon>
+  //   </Tooltip>
+  // )
 
   return (
     <Flex css={S.root} className={className} align="center" justify="space-between">
       {token}
 
       <Flex align="center" gap="sm">
-        {enrichButton}
+        {/* {enrichButton} */}
 
         <Select data={viewOptions} value={currentView} onChange={handleViewChange} />
       </Flex>

--- a/seta-react/src/pages/SearchWithFilters/components/ApplyFilters/ApplyFilters.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/ApplyFilters/ApplyFilters.tsx
@@ -53,10 +53,11 @@ const ApplyFilters = ({ status, onApplyFilters, onClear }: Props) => {
     modified = null
   }
 
-  const buttonStyle =
-    status?.status === FilterStatus.APPLIED || status?.status === FilterStatus.PROCESSING
-      ? S.buttonInactive
-      : undefined
+  const buttonStyle = [
+    (status?.status === FilterStatus.APPLIED || status?.status === FilterStatus.PROCESSING) &&
+      S.buttonInactive,
+    S.button
+  ]
 
   return (
     <HoverCard
@@ -75,6 +76,7 @@ const ApplyFilters = ({ status, onApplyFilters, onClear }: Props) => {
     >
       <HoverCard.Target>
         <Indicator
+          css={S.indicator}
           color={color}
           size={24}
           inline

--- a/seta-react/src/pages/SearchWithFilters/components/ApplyFilters/styles.ts
+++ b/seta-react/src/pages/SearchWithFilters/components/ApplyFilters/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react'
+import type { MantineTheme } from '@mantine/core'
 import { createStyles } from '@mantine/core'
 
 export const useStyles = createStyles(theme => {
@@ -14,6 +15,21 @@ export const useStyles = createStyles(theme => {
     }
   }
 })
+
+const getTransition = (theme: MantineTheme) =>
+  [
+    `color 200ms ${theme.transitionTimingFunction}`,
+    `background-color 200ms ${theme.transitionTimingFunction}`,
+    `border-color 200ms ${theme.transitionTimingFunction}`
+  ].join(', ')
+
+export const indicator: ThemedCSS = theme => css`
+  transition: ${getTransition(theme)};
+`
+
+export const button: ThemedCSS = theme => css`
+  transition: ${getTransition(theme)};
+`
 
 export const buttonInactive: ThemedCSS = theme => css`
   && {

--- a/seta-react/src/types/user.ts
+++ b/seta-react/src/types/user.ts
@@ -1,0 +1,7 @@
+export type User = {
+  email: string
+  firstName: string
+  lastName: string
+  role: string
+  username: string
+}


### PR DESCRIPTION
- Added redirection to login when an API call fails
- Changed to fetch and keep the current user in a context, allowing accessing it via a custom hook
- Checking all protected routes if the user exists, otherwise redirecting to login
- Replaced the initial Search menu link with the one for the new page
- Temporarily removed the Enrich button from the suggestions dropdown
- Made a few other UI improvements