### PR TITLE
[seta-react] Reimplement the app Header with Mantine

### DIFF
--- a/seta-react/src/api/auth.ts
+++ b/seta-react/src/api/auth.ts
@@ -36,3 +36,6 @@ export const useUserInfo = (options: UseUserInfoOptions) =>
   })
 
 export const refreshToken = async () => api.get(REFRESH_TOKEN_API_PATH, apiConfig)
+
+export const logout = async () =>
+  api.post('/logout', { 'Cache-Control': 'no-cache', Pragma: 'no-cache' }, apiConfig)

--- a/seta-react/src/components/Header/Header.tsx
+++ b/seta-react/src/components/Header/Header.tsx
@@ -1,166 +1,102 @@
-import type { MouseEventHandler } from 'react'
-import { useRef } from 'react'
-import { Button } from 'primereact/button'
-import { InputText } from 'primereact/inputtext'
-import { Menubar } from 'primereact/menubar'
-import type { MenuItem, MenuItemTemplateType } from 'primereact/menuitem'
-import { TieredMenu } from 'primereact/tieredmenu'
-import { Link, NavLink } from 'react-router-dom'
+import { ActionIcon, Flex, Image, Loader, Menu, Tooltip } from '@mantine/core'
+import { AiOutlineUser } from 'react-icons/ai'
+import { FaSignInAlt } from 'react-icons/fa'
+import { Link } from 'react-router-dom'
 
 import { useCurrentUser } from '~/contexts/user-context'
 
-import authentificationService from '../../services/authentification.service'
+import SiteHeader from './components/SiteHeader'
+import { getDropdownItems, getMenuItems, itemIsDivider } from './config'
+import * as S from './styles'
 
 import './style.css'
 
-const navLinkTemplate: MenuItemTemplateType = item => {
-  const { label, icon, url, command } = item
-
-  if (!url) {
-    return <span>{label}</span>
-  }
-
-  // Set up the click handler if a command is provided on the item.
-  // This will allows us to execute the command when the link is clicked.
-  const clickHandler: MouseEventHandler<HTMLAnchorElement> | undefined = command
-    ? e =>
-        command({
-          originalEvent: e,
-          item
-        })
-    : undefined
-
-  return (
-    <NavLink to={url} className="p-menuitem-link" onClick={clickHandler}>
-      {icon && <i className={icon} />}
-      <span className="p-menuitem-text">{label}</span>
-    </NavLink>
-  )
-}
-
-const navStart = (
-  <Link to="/" className="mr-5">
-    <img alt="SeTa Logo" src="/img/SeTA-logocut-negative.png" height="40" />
-  </Link>
-)
-
-const navEnd = (
-  <Link to="/login">
-    <span className="p-menuitem-icon pi pi-sign-in p-menuitem p-menuitem-link border-round" />
-  </Link>
-)
-
 const Header = () => {
-  const dashboard = useRef<TieredMenu>(null)
-
-  const { user } = useCurrentUser()
+  const { user, isLoading: isUserLoading, logout } = useCurrentUser()
 
   const authenticated = !!user
 
-  const navMenu: MenuItem[] = [
-    {
-      label: 'Search',
-      className: 'seta-item',
-      url: '/search',
-      visible: authenticated,
-      template: navLinkTemplate
-    },
-    {
-      label: 'Communities',
-      className: 'seta-item',
-      url: '/communities',
-      visible: authenticated,
-      template: navLinkTemplate
-    },
-    {
-      label: 'Faqs',
-      className: 'seta-item',
-      url: '/faqs',
-      template: navLinkTemplate
-    },
-    {
-      label: 'Contact',
-      className: 'seta-item',
-      url: '/contact',
-      template: navLinkTemplate
+  const handleLogout = () => {
+    logout()
+    window.location.href = '/login'
+  }
+
+  const menuItems = getMenuItems(authenticated)
+  const dropdownItems = getDropdownItems({ onLogout: handleLogout })
+
+  const visibleMenuItems = menuItems.filter(link => !link.hidden)
+
+  const dropdownMenuItems = dropdownItems.map((item, index) => {
+    if (itemIsDivider(item)) {
+      // eslint-disable-next-line react/no-array-index-key
+      return <Menu.Divider key={index} />
     }
-  ]
 
-  // Hide the menu when clicking on a menu item
-  const hideMenuCommand = ({ originalEvent }) => dashboard.current?.toggle(originalEvent)
+    const { label, icon, url, onClick } = item
 
-  const dashboardMenu: MenuItem[] = [
-    {
-      label: 'Profile',
-      icon: 'pi pi-fw pi-user',
-      url: '/profile',
-      template: navLinkTemplate,
-      command: hideMenuCommand
-    },
-    {
-      label: 'Dashboard',
-      icon: 'pi pi-fw pi-wrench',
-      url: '/dashboard',
-      template: navLinkTemplate,
-      command: hideMenuCommand
-    },
-    {
-      separator: true
-    },
-    {
-      label: 'Sign Out',
-      icon: 'pi pi-fw pi-sign-out',
-
-      command: () => {
-        authentificationService.setaLogout()
-      }
+    if (url) {
+      return (
+        <Menu.Item key={label} icon={icon} component={Link} to={url}>
+          {label}
+        </Menu.Item>
+      )
     }
-  ]
 
-  const logout = (
-    <div>
-      <TieredMenu model={dashboardMenu} popup ref={dashboard} id="overlay_tmenu" />
+    return (
+      <Menu.Item key={label} icon={icon} onClick={onClick}>
+        {label}
+      </Menu.Item>
+    )
+  })
 
-      <Button
-        icon="pi pi-user"
-        onClick={event => dashboard.current?.toggle(event)}
-        aria-haspopup
-        aria-controls="overlay_tmenu"
-        tooltip="Profile menu"
-        tooltipOptions={{ className: 'blue-tooltip', position: 'top' }}
-      />
-    </div>
+  const dropdownMenu = (
+    <Menu shadow="md" width={200} position="bottom-end">
+      <Menu.Target>
+        <ActionIcon css={S.dropdownTarget} variant="outline" color="gray.1" radius="xl" size="xl">
+          <AiOutlineUser size="1.3rem" />
+        </ActionIcon>
+      </Menu.Target>
+
+      <Menu.Dropdown css={S.dropdown}>{dropdownMenuItems}</Menu.Dropdown>
+    </Menu>
+  )
+
+  const loginButton = (
+    <Tooltip label="Sign in">
+      <ActionIcon
+        variant={isUserLoading ? 'transparent' : 'outline'}
+        color="gray.1"
+        radius="xl"
+        size="xl"
+        component={Link}
+        to="/login"
+        disabled={isUserLoading}
+      >
+        {isUserLoading ? <Loader size="sm" color="gray.3" /> : <FaSignInAlt size="1.3rem" />}
+      </ActionIcon>
+    </Tooltip>
   )
 
   return (
-    <div>
-      <header className="site-header">
-        <div className="container-fluid">
-          <a href="https://ec.europa.eu/info/index_en">
-            <img
-              alt="EC Logo"
-              src="https://commission.europa.eu/themes/contrib/oe_theme/dist/ec/images/logo/positive/logo-ec--en.svg"
-              height="40"
-              className="mr-2"
-            />
-          </a>
+    <header>
+      <SiteHeader />
 
-          <div className="p-inputgroup searches">
-            <InputText placeholder="Search" type="text" className="search-form" />
-            <Button
-              label="Search"
-              className="searchButton"
-              tooltip="Search on the website"
-              tooltipOptions={{ className: 'blue-tooltip', position: 'right' }}
-            />
-          </div>
-        </div>
-      </header>
+      <Flex css={S.menu} align="center" justify="space-between">
+        <Flex align="center">
+          <Link to="/" className="mr-5">
+            <Image alt="SeTa Logo" src="/img/SeTA-logocut-negative.png" width={120} />
+          </Link>
 
-      <header className="seta-header">
-        <Menubar model={navMenu} start={navStart} end={authenticated ? logout : navEnd} />
-      </header>
-    </div>
+          {visibleMenuItems.map(({ to, label }) => (
+            <S.MenuLink key={to} to={to}>
+              {label}
+            </S.MenuLink>
+          ))}
+        </Flex>
+
+        {authenticated ? dropdownMenu : loginButton}
+      </Flex>
+    </header>
   )
 }
 

--- a/seta-react/src/components/Header/components/SiteHeader.tsx
+++ b/seta-react/src/components/Header/components/SiteHeader.tsx
@@ -1,0 +1,31 @@
+import { Button } from 'primereact/button'
+import { InputText } from 'primereact/inputtext'
+
+const SiteHeader = () => {
+  return (
+    <div className="site-header">
+      <div className="container-fluid">
+        <a href="https://ec.europa.eu/info/index_en">
+          <img
+            alt="EC Logo"
+            src="https://commission.europa.eu/themes/contrib/oe_theme/dist/ec/images/logo/positive/logo-ec--en.svg"
+            height="40"
+            className="mr-2"
+          />
+        </a>
+
+        <div className="p-inputgroup searches">
+          <InputText placeholder="Search" type="text" className="search-form" />
+          <Button
+            label="Search"
+            className="searchButton"
+            tooltip="Search on the website"
+            tooltipOptions={{ className: 'blue-tooltip', position: 'right' }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SiteHeader

--- a/seta-react/src/components/Header/config.tsx
+++ b/seta-react/src/components/Header/config.tsx
@@ -1,0 +1,65 @@
+import { FaUser, FaWrench } from 'react-icons/fa'
+import { FiLogOut } from 'react-icons/fi'
+
+type MenuItem = {
+  to: string
+  label: string
+  hidden?: boolean
+}
+
+type DropdownItem =
+  | {
+      label: string
+      icon: JSX.Element
+      url?: string
+      onClick?: () => void
+    }
+  | { divider: true }
+
+export const getMenuItems = (authenticated: boolean): MenuItem[] => [
+  {
+    to: '/search',
+    label: 'Search',
+    hidden: !authenticated
+  },
+  {
+    to: '/communities',
+    label: 'Communities',
+    hidden: !authenticated
+  },
+  {
+    to: '/faqs',
+    label: 'Faqs'
+  },
+  {
+    to: '/contact',
+    label: 'Contact'
+  }
+]
+
+type DropdownCallbacks = {
+  onLogout: () => void
+}
+
+export const getDropdownItems = ({ onLogout }: DropdownCallbacks): DropdownItem[] => [
+  {
+    label: 'Profile',
+    icon: <FaUser size="1.1rem" />,
+    url: '/profile'
+  },
+  {
+    label: 'Dashboard',
+    icon: <FaWrench size="1.1rem" />,
+    url: '/dashboard'
+  },
+  {
+    divider: true
+  },
+  {
+    label: 'Sign Out',
+    icon: <FiLogOut size="1.1rem" />,
+    onClick: onLogout
+  }
+]
+
+export const itemIsDivider = (item: DropdownItem): item is { divider: true } => 'divider' in item

--- a/seta-react/src/components/Header/styles.ts
+++ b/seta-react/src/components/Header/styles.ts
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react'
+import styled from '@emotion/styled'
+import { NavLink } from 'react-router-dom'
+
+export const menu: ThemedCSS = theme => css`
+  background-color: ${theme.other.jrcBlue};
+  padding: 0.75rem 3%;
+`
+
+export const MenuLink = styled(NavLink)`
+  padding: 0.5rem 1.25rem;
+  color: white;
+  border-radius: 4px;
+  background-color: transparent;
+  transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    ${({ theme }) => ({
+      backgroundColor: theme.fn.rgba(theme.colors.gray[1], 0.2),
+      color: theme.colors.gray[1]
+    })};
+  }
+
+  &:active {
+    transition: none;
+    transform: translateY(1px);
+  }
+
+  &.active {
+    ${({ theme }) => ({
+      backgroundColor: theme.colors.gray[1],
+      color: theme.other.jrcBlue,
+      transform: 'scale(1.05)'
+    })};
+  }
+
+  & + & {
+    margin-left: 0.5rem;
+  }
+`
+
+export const dropdownTarget: ThemedCSS = theme => css`
+  opacity: 0.85;
+  transition: background-color 0.2s ease;
+
+  &[data-expanded='true'] {
+    background-color: ${theme.fn.rgba(theme.colors.gray[3], 0.2)};
+  }
+`
+
+export const dropdown: ThemedCSS = theme => css`
+  & .seta-Menu-itemIcon {
+    color: ${theme.colors.gray[7]};
+  }
+`

--- a/seta-react/src/contexts/user-context.tsx
+++ b/seta-react/src/contexts/user-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { isAxiosError } from 'axios'
 
-import { useUserInfo } from '~/api/auth'
+import { logout, useUserInfo } from '~/api/auth'
 import type { ChildrenProp } from '~/types/children-props'
 import type { User } from '~/types/user'
 
@@ -9,6 +9,7 @@ type UserContextProps = {
   user: User | null
   isLoading: boolean
   verify: () => void
+  logout: () => Promise<unknown>
 }
 
 const UserContext = createContext<UserContextProps | undefined>(undefined)
@@ -65,7 +66,8 @@ export const UserProvider = ({ children }: ChildrenProp) => {
   const value: UserContextProps = {
     user,
     isLoading: loading,
-    verify: verifyUser
+    verify: verifyUser,
+    logout
   }
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>


### PR DESCRIPTION
## Description

This PR reimplements the application's header, including the dropdown menu and the login button, with Mantine components and the new auth flow.

## Screenshots

<img width="1453" alt="Captură de ecran din 2023-06-07 la 21 13 00" src="https://github.com/vidaud/seta/assets/127730071/906df2e8-9622-426a-9429-4ede6b4744ae">

---

<img width="1451" alt="Captură de ecran din 2023-06-07 la 21 11 59" src="https://github.com/vidaud/seta/assets/127730071/6e46bb3f-c6cd-4859-9388-d7d02395d553">

---

<img width="1450" alt="Captură de ecran din 2023-06-07 la 21 14 02" src="https://github.com/vidaud/seta/assets/127730071/3c52aca7-5ada-4761-b57d-8efa2203dce4">

## How to test

- Log into the app
- Check that the main menu navigates to the correct pages
- Verify that the dropdown menu opens and all the items work as expected
- Verify that the `Sign out` option signs out the user
- While the user is not logged in, verify that the dropdown menu is replaced by the `Sign in` button which navigates to the corresponding page.