### PR TITLE
[seta-ui] Membership request and profile fixes

### DIFF
--- a/seta-ui/seta_flask_server/blueprints/communities/models/membership_dto.py
+++ b/seta-ui/seta_flask_server/blueprints/communities/models/membership_dto.py
@@ -44,8 +44,8 @@ update_request_parser.add_argument("status",
                                   required=True,
                                   nullable=False,
                                   case_sensitive=False,
-                                  choices=RequestStatusConstants.List,
-                                  help=f"Status, one of {RequestStatusConstants.EditList}")
+                                  choices=RequestStatusConstants.EditList,
+                                  help=f"Request status")
 
 request_model = Model("MembershipRequest",
         {

--- a/seta-ui/seta_flask_server/blueprints/profile/models/scopes_dto.py
+++ b/seta-ui/seta_flask_server/blueprints/profile/models/scopes_dto.py
@@ -14,7 +14,7 @@ community_scopes_model = Model("CommunityScopes",{
 })
 
 resource_scopes_model = Model("ResourceScopes",{
-    "community_id": fields.String(description="Identifier"),
+    "resource_id": fields.String(description="Identifier"),
     "scopes": fields.List(fields.String(description="Scope", enum=ResourceScopeConstants.List))
 })
 

--- a/seta-ui/seta_flask_server/repository/interfaces/membership_broker.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/membership_broker.py
@@ -37,7 +37,7 @@ class IMembershipsBroker(Interface):
     def get_request(self, community_id: str, user_id: str) -> MembershipRequestModel:
         pass
     
-    def get_requests_by_community_id(self, community_id: str) -> list[MembershipRequestModel]:
+    def get_requests_by_community_id(self, community_id: str, status: str = None) -> list[MembershipRequestModel]:
         pass
     
     def get_requests_by_user_id(self, user_id: str) -> list[MembershipRequestModel]:


### PR DESCRIPTION
Membership requests:
* manager can get only the pending requests
* prevent updating an accepted/rejected request
* user can perform another membership request after leaving the same community

My permissions:
* fix resource_id field for the scope list