### PR TITLE
[seta-react] Add Enrich support & fix documents score

### DIFF
--- a/seta-react/src/api/search/documents.ts
+++ b/seta-react/src/api/search/documents.ts
@@ -40,9 +40,9 @@ export type DocumentsOptions = Omit<DocumentsPayload, 'from_doc' | 'n_docs'>
 
 export const queryKey = {
   root: 'documents',
-  docs: (term: string, page: number, perPage: number, searchOptions?: DocumentsOptions) => [
+  docs: (query: string, page: number, perPage: number, searchOptions?: DocumentsOptions) => [
     queryKey.root,
-    term,
+    query,
     { page, perPage },
     { searchOptions }
   ]
@@ -89,8 +89,8 @@ export const useDocuments = (
     queryFn: ({ signal }) =>
       getDocuments(
         {
-          ...searchOptions,
           term: query,
+          ...searchOptions,
           from_doc: getOffset(page, perPage),
           n_docs: perPage
         },

--- a/seta-react/src/api/search/query.ts
+++ b/seta-react/src/api/search/query.ts
@@ -1,0 +1,33 @@
+import type { AxiosRequestConfig } from 'axios'
+
+import type { EnrichType } from '~/pages/SearchPageNew/types/search'
+
+import api from '~/api'
+
+const ENRICH_API_PATH = '/term_enrichment'
+
+type EnrichedTermsResponse = {
+  words: string[]
+}
+
+export const getEnrichedTerms = async (
+  terms: string[],
+  enrichType: EnrichType,
+  config?: AxiosRequestConfig
+): Promise<EnrichedTermsResponse> => {
+  if (!terms?.length) {
+    return { words: [] }
+  }
+
+  const termsString = terms.join(',')
+
+  const { data } = await api.get<EnrichedTermsResponse>(`${ENRICH_API_PATH}`, {
+    ...config,
+    params: {
+      terms: termsString,
+      enrichment_type: enrichType
+    }
+  })
+
+  return data
+}

--- a/seta-react/src/pages/SearchPageNew/components/SearchInput/SearchInput.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchInput/SearchInput.tsx
@@ -2,6 +2,8 @@ import { forwardRef } from 'react'
 import { ActionIcon, Button, Flex, Tooltip } from '@mantine/core'
 import { IconCloudUp, IconSearch } from '@tabler/icons-react'
 
+import { useEnrichLoading } from '~/pages/SearchPageNew/contexts/enrich-loading-context'
+
 import * as S from './styles'
 
 import TokensInput from '../TokensInput'
@@ -16,6 +18,8 @@ type Props = {
 
 const SearchInput = forwardRef<HTMLDivElement, Props>(
   ({ className, value, onDeferredChange, onClick, onSearch }, ref) => {
+    const { loading } = useEnrichLoading()
+
     const allowSearch = (value?.trim().length ?? 0) > 1
 
     return (
@@ -43,6 +47,7 @@ const SearchInput = forwardRef<HTMLDivElement, Props>(
               leftIcon={<IconSearch />}
               onClick={onSearch}
               disabled={!allowSearch}
+              loading={loading}
             >
               Search
             </Button>

--- a/seta-react/src/pages/SearchPageNew/components/SearchInput/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchInput/styles.ts
@@ -36,9 +36,21 @@ export const searchButton: ThemedCSS = theme => css`
 
   transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
 
-  &:disabled {
+  &:disabled,
+  &[data-loading='true'] {
     opacity: 0.7;
     background-color: ${theme.fn.primaryColor()};
     color: ${theme.colors.blue[1]};
+  }
+
+  &[data-loading='true'] {
+    &::before {
+      background-color: transparent;
+    }
+
+    & .seta-Button-leftIcon {
+      margin-left: 2px;
+      margin-right: 11px;
+    }
   }
 `

--- a/seta-react/src/pages/SearchPageNew/components/SearchSuggestionInput/SearchSuggestionInput.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchSuggestionInput/SearchSuggestionInput.tsx
@@ -4,7 +4,8 @@ import { Box } from '@mantine/core'
 import SuggestionsPopup from '~/pages/SearchPageNew/components/SuggestionsPopup'
 import { SearchProvider } from '~/pages/SearchPageNew/contexts/search-context'
 import { SearchInputProvider } from '~/pages/SearchPageNew/contexts/search-input-context'
-import type { SearchValue } from '~/pages/SearchPageNew/types/search'
+import type { EnrichedStatus, SearchValue } from '~/pages/SearchPageNew/types/search'
+import { EnrichType } from '~/pages/SearchPageNew/types/search'
 import type { Token, TokenMatch } from '~/pages/SearchPageNew/types/token'
 
 import type { ClassNameProp } from '~/types/children-props'
@@ -35,6 +36,11 @@ const SearchSuggestionInput = ({ className, onSearch }: Props) => {
   const [value, setValue] = useState('')
   const [tokens, setTokens] = useState<Token[]>([])
   const [currentToken, setCurrentToken] = useState<TokenMatch | null>(null)
+
+  const [enrichedStatus, setEnrichedStatus] = useState<EnrichedStatus>({
+    enriched: false,
+    type: EnrichType.Similar
+  })
 
   const handleSuggestionSelected = (suggestion: string) => {
     const replaceWith = suggestion.match(/\s/g) ? `"${suggestion}"` : suggestion
@@ -72,7 +78,7 @@ const SearchSuggestionInput = ({ className, onSearch }: Props) => {
   }
 
   const handleSearch = () => {
-    onSearch({ value, tokens })
+    onSearch({ value, tokens, enrichedStatus })
   }
 
   return (
@@ -88,7 +94,10 @@ const SearchSuggestionInput = ({ className, onSearch }: Props) => {
         onSearch={handleSearch}
       >
         <SearchInputProvider inputValue={value} setInputValue={setValue}>
-          <SuggestionsPopup />
+          <SuggestionsPopup
+            enrichQuery={enrichedStatus.enriched}
+            onEnrichToggle={setEnrichedStatus}
+          />
         </SearchInputProvider>
       </SearchProvider>
     </Box>

--- a/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/SuggestionsPopup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/SuggestionsPopup.tsx
@@ -5,6 +5,8 @@ import { IconX } from '@tabler/icons-react'
 
 import { useSearch } from '~/pages/SearchPageNew/contexts/search-context'
 import { useSearchInput } from '~/pages/SearchPageNew/contexts/search-input-context'
+import type { EnrichedStatus } from '~/pages/SearchPageNew/types/search'
+import { EnrichType } from '~/pages/SearchPageNew/types/search'
 import { TermsView } from '~/pages/SearchPageNew/types/terms-view'
 
 import * as S from './styles'
@@ -15,20 +17,24 @@ import TermsSuggestions from '../TermsSuggestions'
 
 type Props = {
   opened?: boolean
+  enrichQuery?: boolean
   onOpenChange?: PopoverProps['onChange']
+  onEnrichToggle?: (status: EnrichedStatus) => void
 }
 
 const TOKEN_RESET_DELAY = 100
 
-const SuggestionsPopup = ({ opened, onOpenChange }: Props) => {
+const SuggestionsPopup = ({ opened, enrichQuery, onOpenChange, onEnrichToggle }: Props) => {
   const [popupOpen, setPopupOpen] = useState(opened ?? false)
   const [termsView, setTermsView] = useState(TermsView.TermsClusters)
-  const [enrichQuery, setEnrichQuery] = useState(false)
 
   const { setCurrentToken, onSearch } = useSearch()
   const { inputValue, setInputValue } = useSearchInput()
 
   const closingTimeoutRef = useRef<number | null>(null)
+
+  const enrichType =
+    termsView === TermsView.TermsClusters ? EnrichType.Ontology : EnrichType.Similar
 
   // Delay the token reset to avoid it disappearing before the animation ends when the popup is closing
   useEffect(() => {
@@ -51,6 +57,16 @@ const SuggestionsPopup = ({ opened, onOpenChange }: Props) => {
     }
   }, [inputValue])
 
+  // Retrigger the event when the view changes
+  useEffect(() => {
+    if (enrichQuery) {
+      onEnrichToggle?.({
+        enriched: true,
+        type: enrichType
+      })
+    }
+  }, [enrichType, enrichQuery, onEnrichToggle])
+
   const handlePopupChange = (value: boolean) => {
     setPopupOpen(value)
     onOpenChange?.(value)
@@ -71,7 +87,10 @@ const SuggestionsPopup = ({ opened, onOpenChange }: Props) => {
   }
 
   const handleEnrichToggle = () => {
-    setEnrichQuery(value => !value)
+    onEnrichToggle?.({
+      enriched: !enrichQuery,
+      type: enrichType
+    })
   }
 
   const handleSearch = () => {

--- a/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/EnrichInfo/EnrichInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/EnrichInfo/EnrichInfo.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@mantine/core'
 import { FaHatWizard } from 'react-icons/fa'
 
-import { TermsView } from '~/pages/SearchPageNew/types/terms-view'
+import type { TermsView } from '~/pages/SearchPageNew/types/terms-view'
 
 import * as S from './styles'
 
@@ -9,8 +9,12 @@ type Props = {
   type: TermsView
 }
 
+// Disabling the warning until the TODO below is resolved
+// eslint-disable-next-line unused-imports/no-unused-vars
 const EnrichInfo = ({ type }: Props) => {
-  const what = type === TermsView.TermsClusters ? 'terms in the related clusters' : 'related terms'
+  // TODO: Uncomment this when the API returns results for ontology enriching in a reasonable time - see also `search-utils.ts`
+  // const what = type === TermsView.TermsClusters ? 'terms in the related clusters' : 'related terms'
+  const what = 'related terms'
 
   return (
     <Flex align="center" justify="center" css={S.root}>

--- a/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/OntologyHeader/OntologyHeader.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/TermsSuggestions/components/OntologyHeader/OntologyHeader.tsx
@@ -1,5 +1,6 @@
 import type { ActionIconProps, ChipProps, SelectItem } from '@mantine/core'
-import { Text, Select, Chip, Flex, Tooltip } from '@mantine/core'
+import { ActionIcon, Text, Select, Chip, Flex, Tooltip } from '@mantine/core'
+import { IconWand } from '@tabler/icons-react'
 
 import { useSearch } from '~/pages/SearchPageNew/contexts/search-context'
 import { useTermsSelection } from '~/pages/SearchPageNew/contexts/terms-selection-context'
@@ -83,20 +84,20 @@ const OntologyHeader = ({
     </Text>
   )
 
-  // const enrichButton = hasToken && (
-  //   <Tooltip label="Enrich query automatically">
-  //     <ActionIcon size="lg" radius="md" onClick={onEnrichToggle} {...enrichedProps}>
-  //       <IconWand />
-  //     </ActionIcon>
-  //   </Tooltip>
-  // )
+  const enrichButton = hasToken && (
+    <Tooltip label="Enrich query automatically">
+      <ActionIcon size="lg" radius="md" onClick={onEnrichToggle} {...enrichedProps}>
+        <IconWand />
+      </ActionIcon>
+    </Tooltip>
+  )
 
   return (
     <Flex css={S.root} className={className} align="center" justify="space-between">
       {token}
 
       <Flex align="center" gap="sm">
-        {/* {enrichButton} */}
+        {enrichButton}
 
         <Select data={viewOptions} value={currentView} onChange={handleViewChange} />
       </Flex>

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Anchor, Flex, Progress, Text, clsx } from '@mantine/core'
+import { Anchor, Flex, Progress, Text, clsx, Tooltip } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { FaChevronDown } from 'react-icons/fa'
 
@@ -33,6 +33,12 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
 
   const hasDetails = !!taxonomy?.length || !!chunk_text
 
+  const scorePercent = score.toLocaleString(undefined, {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+
   const toggleIcon = hasDetails && (
     <div css={S.chevron} className={chevronClass}>
       <FaChevronDown />
@@ -41,8 +47,12 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
 
   return (
     <div css={S.root} className={openClass}>
-      <div css={S.header} data-details={hasDetails} onClick={toggle}>
-        <Progress size="xl" value={score} color="teal" />
+      <div css={S.header} data-details={hasDetails} data-open={detailsOpen} onClick={toggle}>
+        <Progress size="xl" value={score * 100} color="teal" />
+
+        <Tooltip className="score" label="Match score" position="bottom">
+          <div>{scorePercent}</div>
+        </Tooltip>
 
         <div css={S.title}>
           <Text fz="xl" fw={600} truncate={detailsOpen ? undefined : 'end'}>

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
@@ -36,9 +36,36 @@ export const header: ThemedCSS = theme => css`
   grid-template-columns: ${PROGRESS_WIDTH} 1fr auto;
   align-items: center;
   gap: ${theme.spacing.lg};
+  position: relative;
 
   & .seta-Progress-bar {
     animation: ${fill} 300ms ease;
+  }
+
+  & .score {
+    position: absolute;
+    opacity: 0;
+    visibility: hidden;
+    left: ${theme.spacing.sm};
+    margin-top: 0;
+    width: ${PROGRESS_WIDTH};
+    text-align: center;
+    font-size: 0.65rem;
+    color: ${theme.colors.gray[5]};
+    cursor: default;
+    transition: all 200ms ${theme.transitionTimingFunction};
+
+    &:hover {
+      color: ${theme.colors.gray[7]};
+    }
+  }
+
+  &[data-open='true'] {
+    & .score {
+      opacity: 1;
+      visibility: visible;
+      margin-top: 2.5rem;
+    }
   }
 
   &[data-details='true'] {

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { useEnrichLoading } from '~/pages/SearchPageNew/contexts/enrich-loading-context'
+
 import type { DocumentsOptions, DocumentsResponse } from '~/api/search/documents'
 import { useDocuments } from '~/api/search/documents'
 import usePaginator from '~/hooks/use-paginator'
@@ -19,6 +21,8 @@ const DocumentsList = ({ query, terms, searchOptions, onDocumentsChanged }: Prop
   const documentsChangedRef = useRef(onDocumentsChanged)
 
   const [page, setPage] = useState(1)
+
+  const { loading: enrichLoading } = useEnrichLoading()
 
   const { data, isLoading, error, refetch } = useDocuments(query, {
     page,
@@ -51,7 +55,7 @@ const DocumentsList = ({ query, terms, searchOptions, onDocumentsChanged }: Prop
     <DocumentsListContent
       ref={scrollTargetRef}
       data={data}
-      isLoading={isLoading}
+      isLoading={isLoading || enrichLoading}
       error={error}
       onTryAgain={refetch}
       queryTerms={terms}

--- a/seta-react/src/pages/SearchPageNew/contexts/enrich-loading-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/contexts/enrich-loading-context.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react'
+
+import type { ChildrenProp } from '~/types/children-props'
+
+type EnrichLoadingContextProps = {
+  loading: boolean
+}
+
+const EnrichLoadingContext = createContext<EnrichLoadingContextProps | undefined>(undefined)
+
+export const EnrichLoadingProvider = ({
+  loading,
+  children
+}: EnrichLoadingContextProps & ChildrenProp) => {
+  const value: EnrichLoadingContextProps = {
+    loading
+  }
+
+  return <EnrichLoadingContext.Provider value={value}>{children}</EnrichLoadingContext.Provider>
+}
+
+export const useEnrichLoading = () => {
+  const context = useContext(EnrichLoadingContext)
+
+  if (!context) {
+    throw new Error('useEnrichLoading must be used within an EnrichLoadingProvider')
+  }
+
+  return context
+}

--- a/seta-react/src/pages/SearchPageNew/types/search.ts
+++ b/seta-react/src/pages/SearchPageNew/types/search.ts
@@ -1,6 +1,17 @@
 import type { Token } from './token'
 
+export enum EnrichType {
+  Similar = 'similar',
+  Ontology = 'ontology'
+}
+
+export type EnrichedStatus = {
+  enriched: boolean
+  type: EnrichType
+}
+
 export type SearchValue = {
   value: string
   tokens: Token[]
+  enrichedStatus: EnrichedStatus
 }

--- a/seta-react/src/pages/SearchPageNew/utils/search-utils.ts
+++ b/seta-react/src/pages/SearchPageNew/utils/search-utils.ts
@@ -1,5 +1,25 @@
+import type { EnrichedStatus } from '~/pages/SearchPageNew/types/search'
+import { EnrichType } from '~/pages/SearchPageNew/types/search'
 import type { Token } from '~/pages/SearchPageNew/types/token'
 
-export const buildSearchQuery = (tokens: Token[]): string => {
-  return tokens.map(({ token }) => token).join(' OR ')
+import { getEnrichedTerms } from '~/api/search/query'
+
+export const buildSearchQueryFromTerms = (terms: string[]): string =>
+  terms.map(term => (term.match(/\s/) ? `"${term}"` : term)).join(' OR ')
+
+export const getSearchQueryAndTerms = async (
+  tokens: Token[],
+  enrichedStatus?: EnrichedStatus
+): Promise<{ query: string; terms: string[] }> => {
+  const selfTerms = tokens.map(({ rawValue }) => rawValue)
+
+  const enrichedTerms = enrichedStatus?.enriched
+    ? // TODO: Replace `EnrichType.Similar` with `enrichedStatus.type` once the API returns the results in a reasonable time
+      (await getEnrichedTerms(selfTerms, EnrichType.Similar)).words
+    : []
+
+  const terms = [...selfTerms, ...enrichedTerms]
+  const query = buildSearchQueryFromTerms(terms)
+
+  return { query, terms }
 }


### PR DESCRIPTION
This PR adds support for the `Enrich query` button.

**Important**: because the call to the enrich API with the option `enrichment_type` as `ontology` takes **a lot of time** even for a few terms, all the expansions are for the moment done as `similar`. The implementation is there but inactive - ready to be enabled once we figure out what to do on the API side for this.

Also adjusted the score display to account for the changes in the API, together with a label shown when the document is expanded.