### PR TITLE
[seta-react] Fix clear filters for multiple values

### DIFF
--- a/seta-react/src/pages/SearchWithFilters/components/FilterInfo/FilterInfo.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/FilterInfo/FilterInfo.tsx
@@ -9,7 +9,7 @@ import { getSourceLists, getTaxonomyLists, getOtherLists, FilterStatusColors } f
 import { FilterStatus } from '../../types/filter-info'
 import type { FilterStatusInfo } from '../../types/filter-info'
 import type { ClearAction } from '../../types/filters'
-import { ClearCategory, ClearType } from '../../types/filters'
+import { ClearCategory, ClearType, TextChunkValues } from '../../types/filters'
 
 type Props = {
   status?: FilterStatusInfo
@@ -34,6 +34,13 @@ const FilterInfo = ({ status, onClear }: Props) => {
   const { taxonomyApplied, taxonomyDeleted, taxonomyAdded } = getTaxonomyLists(status)
   const { otherApplied, otherDeleted, otherAdded } = getOtherLists(status)
 
+  const clearAllDisabled =
+    status?.prevStatus === FilterStatus.UNKNOWN ||
+    (status?.prevStatus === FilterStatus.APPLIED &&
+      status?.applied() === 1 &&
+      status?.currentFilter?.chunkValue === TextChunkValues.CHUNK_SEARCH)
+  const clearModifiedDisabled = status?.modified() === 0
+
   return (
     <ScrollArea.Autosize mx="auto" mah={rem(500)}>
       <Container fluid p={5}>
@@ -43,7 +50,7 @@ const FilterInfo = ({ status, onClear }: Props) => {
             leftIcon={<IconClearAll size={rem(16)} />}
             color={FilterStatusColors.APPLIED}
             variant="outline"
-            disabled={status?.prevStatus === FilterStatus.UNKNOWN}
+            disabled={clearAllDisabled}
             onClick={e => {
               e.stopPropagation()
               onClear?.({ type: ClearType.ALL })
@@ -56,7 +63,7 @@ const FilterInfo = ({ status, onClear }: Props) => {
             leftIcon={<IconClearAll size={rem(16)} />}
             color={FilterStatusColors.MODIFIED}
             variant="outline"
-            disabled={status?.modified() === 0}
+            disabled={clearModifiedDisabled}
             onClick={e => {
               e.stopPropagation()
               onClear?.({ type: ClearType.ALL_MODIFIED })

--- a/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { Container, Flex, Accordion, ScrollArea, rem, Text } from '@mantine/core'
-import { useLogger } from '@mantine/hooks'
 
 import { itemsReducer } from './items-reducer'
 import TinyChart from './TinyChart'
@@ -46,8 +45,6 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
     dispatchOtherItems,
     filterData
   } = useFilter(queryContract, resourceSelectedKeys, taxonomySelectedKeys)
-
-  useLogger('FiltersPanel', [status])
 
   useEffect(() => {
     statusChangeRef.current?.(status.status)

--- a/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/status-reducer.ts
+++ b/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/status-reducer.ts
@@ -5,8 +5,14 @@ import { ViewFilterInfo, FilterStatus } from '../../types/filter-info'
 import type { RangeValue } from '../../types/filters'
 import { OtherItemStatus } from '../../types/other-filter'
 
-const compareRanges = (range1: RangeValue, range2?: RangeValue | null): boolean => {
-  if (range2 === undefined || range2 === null) {
+const compareRanges = (range1?: RangeValue, range2?: RangeValue | null): boolean => {
+  //both undefined or null
+  if ((range1 === undefined || range1 === null) && (range2 === undefined || range2 === null)) {
+    return true
+  }
+
+  //one of them udefined or null
+  if (range1 === undefined || range1 === null || range2 === undefined || range2 === null) {
     return false
   }
 
@@ -15,7 +21,9 @@ const compareRanges = (range1: RangeValue, range2?: RangeValue | null): boolean 
 
 const sourceChanged = (info: FilterStatusInfo, values) => {
   const keys = info.appliedFilter?.sourceValues?.map(s => s.key)
-  const { removed, added } = keysDiff(keys, values)
+  const valueKeys = values?.map(v => v.key)
+
+  const { removed, added } = keysDiff(keys, valueKeys)
 
   info.sourceModified = removed.length + added.length
 
@@ -38,7 +46,9 @@ const sourceChanged = (info: FilterStatusInfo, values) => {
 
 const taxonomyChanged = (info: FilterStatusInfo, values) => {
   const keys = info.appliedFilter?.taxonomyValues?.map(s => s.key)
-  const { removed, added } = keysDiff(keys, values)
+  const valueKeys = values?.map(v => v.key)
+
+  const { removed, added } = keysDiff(keys, valueKeys)
 
   info.taxonomyModified = removed.length + added.length
 


### PR DESCRIPTION
Fix clear filters for resources and taxonomies.

Disable clear all when the 'First Chunk' is the only applied filter