### PR TITLE
[seta-react] Fix searching without keywords

### DIFF
--- a/seta-react/src/pages/SearchPageNew/components/SearchInput/SearchInput.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchInput/SearchInput.tsx
@@ -82,7 +82,12 @@ const SearchInput = forwardRef<HTMLDivElement, Props>(
           onChange={onDeferredChange}
         />
 
-        <Tooltip label="Type a keyword to enable searching" disabled={allowSearching}>
+        <Tooltip
+          label="Type a keyword or upload a document to enable searching"
+          multiline
+          width={300}
+          disabled={allowSearching}
+        >
           <div css={S.searchButtonWrapper} data-disabled={!allowSearching}>
             <Button
               css={S.searchButton}

--- a/seta-react/src/utils/search-utils.ts
+++ b/seta-react/src/utils/search-utils.ts
@@ -36,6 +36,11 @@ const getQueryAndTermsFromTokens = async (
   const groups: string[][] = [[]]
   const terms: string[] = []
 
+  // Exit early if there are no tokens to search for
+  if (!tokens.length) {
+    return ['', []]
+  }
+
   for (const [index, token] of tokens.entries()) {
     const { operator, token: value } = token
 
@@ -62,8 +67,14 @@ const getQueryAndTermsFromTokens = async (
   }
 
   // Clean up empty groups caused by consecutive `AND` operators at the end
-  while (groups[groups.length - 1].length === 0) {
+  // or by having only `AND`/`OR` operators in the query
+  while (groups[groups.length - 1]?.length === 0) {
     groups.pop()
+  }
+
+  // Exit early if there are no groups
+  if (!groups.length) {
+    return ['', []]
   }
 
   if (enrichedStatus?.enriched) {


### PR DESCRIPTION
This PR fixes two situations that made the search page fail while searching:

- Trying to search only with uploads, without any keyword
- Trying to search for something like `AND` or `OR` (or any combination of operators only, without keywords)

Also, improved a bit the Search button tooltip text when disabled.