### PR TITLE
Update API calls params & remove Notifications provider reference

### DIFF
--- a/seta-react/src/api/search/related-clusters.ts
+++ b/seta-react/src/api/search/related-clusters.ts
@@ -24,7 +24,7 @@ const getRelatedClusters = async (
   }
 
   const { data } = await api.get<RelatedClustersResponse>(
-    `${RELATED_CLUSTERS_API_PATH}?terms=${words}`,
+    `${RELATED_CLUSTERS_API_PATH}?term=${words}`,
     config
   )
 

--- a/seta-react/src/api/search/related-terms.ts
+++ b/seta-react/src/api/search/related-terms.ts
@@ -24,7 +24,7 @@ const getRelatedTerms = async (
   }
 
   const { data } = await api.get<RelatedTermsResponse>(
-    `${RELATED_TERMS_API_PATH}?terms=${words}`,
+    `${RELATED_TERMS_API_PATH}?term=${words}`,
     config
   )
 

--- a/seta-react/src/components/Header/Header.tsx
+++ b/seta-react/src/components/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { ActionIcon, Flex, Group, Image, Loader, Menu, Tooltip, Badge } from '@mantine/core'
 import { AiOutlineUser } from 'react-icons/ai'
 import { FaSignInAlt } from 'react-icons/fa'
@@ -10,18 +9,14 @@ import { getDropdownItems, getMenuItems, itemIsCollapse, itemIsDivider } from '.
 import * as S from './styles'
 
 import { useCurrentUser } from '../../contexts/user-context'
-import { useNotifications } from '../../pages/CommunitiesPage/pages/contexts/notifications-context'
 
 import './style.css'
 
 const Header = () => {
   const { user, isLoading: isUserLoading, logout } = useCurrentUser()
-  const { notifications, total, getNotificationRequests } = useNotifications()
 
-  useEffect(() => {
-    getNotificationRequests()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  // FIXME: This is just a placeholder for the notifications data
+  const [notifications, total] = [[], 0]
 
   const authenticated = !!user
   const role = user?.role === 'Administrator'

--- a/seta-react/src/components/Header/components/NotificationsMenu.tsx
+++ b/seta-react/src/components/Header/components/NotificationsMenu.tsx
@@ -18,10 +18,11 @@ type Props = {
 const NotificationsMenu = ({ total, dropdownItems, notifications }: Props) => {
   const { classes } = useStyles()
 
+  // FIXME: This needs to be fixed - Array.map should always return a value
   const notificationsMenuItems = dropdownItems.map((item, index) => {
     if (itemIsCollapse(item)) {
-      // eslint-disable-next-line react/no-array-index-key
       return (
+        // FIXME: We should try to avoid using index as a key when possible - see https://adhithiravi.medium.com/why-do-i-need-keys-in-react-lists-dbb522188bbb
         // eslint-disable-next-line react/no-array-index-key
         <Menu.Item key={index}>
           <Group position="apart" spacing={0} sx={{ paddingBottom: '1rem' }}>

--- a/seta-react/src/layouts/AppLayout/AppLayout.tsx
+++ b/seta-react/src/layouts/AppLayout/AppLayout.tsx
@@ -3,13 +3,10 @@ import { Outlet } from 'react-router-dom'
 
 import Footer from '../../components/Footer'
 import Header from '../../components/Header'
-import { NotificationsProvider } from '../../pages/CommunitiesPage/pages/contexts/notifications-context'
 
 const AppLayout = () => (
   <Flex direction="column" className="min-h-screen">
-    <NotificationsProvider>
-      <Header />
-    </NotificationsProvider>
+    <Header />
 
     <Flex direction="column" mih="600px" sx={{ flexGrow: 1 }}>
       <Outlet />


### PR DESCRIPTION
This PR changes the API params used in the frontend according to the latest changes.

Also, removes the NotificationsProvider usage in AppLayout to fix the infinite reload of the login page.