### PR TITLE
[seta-react] Add initial documents folder

### DIFF
--- a/seta-react/docs/eslint-configuration.md
+++ b/seta-react/docs/eslint-configuration.md
@@ -39,14 +39,12 @@ Open the project's `.vscode/settings.json` file and add the following configurat
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "editor.formatOnSave": false,
-  "eslint.workingDirectories": [
-      "./seta-react"
-  ]
+  "editor.formatOnSave": false
 }
 ```
 
 Note: when the folder `seta` is the root of the opened project (the parent of `seta-react`), then add the following to the `.vscode/settings.json` file
+
 ```json
 {
   ...

--- a/seta-react/package.json
+++ b/seta-react/package.json
@@ -65,6 +65,7 @@
     "svgo": "^2.7.0",
     "typescript": "^4.9.3",
     "typescript-cookie": "^1.0.4",
+    "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {

--- a/seta-react/src/api/admin/community-requests.ts
+++ b/seta-react/src/api/admin/community-requests.ts
@@ -12,7 +12,10 @@ const COMMUNITY_REQUESTS_API_PATH = '/admin/communities/change-requests'
 const getPendingRequests = async (
   config?: AxiosRequestConfig
 ): Promise<CommunityChangeRequest[]> => {
-  const { data } = await api.get<CommunityChangeRequest[]>(COMMUNITY_REQUESTS_API_PATH, config)
+  const { data } = await api.get<CommunityChangeRequest[]>(COMMUNITY_REQUESTS_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
@@ -20,7 +23,7 @@ const getPendingRequests = async (
 export const useCommunityPendingRequests = () => {
   return useQuery({
     queryKey: AdminQueryKeys.CommunityRequestsQueryKey,
-    queryFn: ({ signal }) => getPendingRequests({ baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getPendingRequests({ signal })
   })
 }
 

--- a/seta-react/src/api/admin/menu-stats.ts
+++ b/seta-react/src/api/admin/menu-stats.ts
@@ -11,13 +11,16 @@ import { AdminQueryKeys } from './query-keys'
 const STATS_LIGHT_API_PATH = '/admin/stats/light'
 
 const getStatsLight = async (config?: AxiosRequestConfig): Promise<LightStatsResponse[]> => {
-  const { data } = await api.get<LightStatsResponse[]>(STATS_LIGHT_API_PATH, config)
+  const { data } = await api.get<LightStatsResponse[]>(STATS_LIGHT_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
 
 const getMenuStats = async (config?: AxiosRequestConfig): Promise<SidebarStats> => {
-  const data = await getStatsLight(config)
+  const data = await getStatsLight({ baseURL: environment.baseUrl, ...config })
 
   return {
     totalChangeRequests: data
@@ -49,13 +52,13 @@ const getMenuStats = async (config?: AxiosRequestConfig): Promise<SidebarStats> 
 export const useAdminSidebarStats = () => {
   return useQuery({
     queryKey: AdminQueryKeys.SidebarQueryKey,
-    queryFn: ({ signal }) => getMenuStats({ baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getMenuStats({ signal })
   })
 }
 
 export const useAdminStatsLight = () => {
   return useQuery({
     queryKey: ['stats-light'],
-    queryFn: ({ signal }) => getStatsLight({ baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getStatsLight({ signal })
   })
 }

--- a/seta-react/src/api/admin/orphaned-communities.ts
+++ b/seta-react/src/api/admin/orphaned-communities.ts
@@ -10,15 +10,18 @@ import { AdminQueryKeys } from './query-keys'
 const ORPHAN_API_PATH = '/admin/orphan/communities'
 
 const getOrphans = async (config?: AxiosRequestConfig): Promise<Community[]> => {
-  const { data } = await api.get<Community[]>(ORPHAN_API_PATH, config)
+  const { data } = await api.get<Community[]>(ORPHAN_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
 
 export const useOrphanedCommunities = () => {
   return useQuery({
-    queryKey: AdminQueryKeys.OphanedCommunitiesQueryKey,
-    queryFn: ({ signal }) => getOrphans({ baseURL: environment.baseUrl, signal })
+    queryKey: AdminQueryKeys.OrphanedCommunitiesQueryKey,
+    queryFn: ({ signal }) => getOrphans({ signal })
   })
 }
 
@@ -49,10 +52,10 @@ export const useSetCommunityOwner = () => {
   return useMutation({
     mutationFn: (request: Request) => setCommunityOwner(request),
     onMutate: async () => {
-      await client.cancelQueries(AdminQueryKeys.OphanedCommunitiesQueryKey)
+      await client.cancelQueries(AdminQueryKeys.OrphanedCommunitiesQueryKey)
     },
     onSuccess: () => {
-      client.invalidateQueries(AdminQueryKeys.OphanedCommunitiesQueryKey)
+      client.invalidateQueries(AdminQueryKeys.OrphanedCommunitiesQueryKey)
       client.invalidateQueries(AdminQueryKeys.SidebarQueryKey)
     }
   })

--- a/seta-react/src/api/admin/orphaned-resources.ts
+++ b/seta-react/src/api/admin/orphaned-resources.ts
@@ -9,14 +9,17 @@ import { AdminQueryKeys } from './query-keys'
 const ORPHAN_API_PATH = '/admin/orphan/resources'
 
 const getOrphans = async (config?: AxiosRequestConfig): Promise<string[]> => {
-  const { data } = await api.get<string[]>(ORPHAN_API_PATH, config)
+  const { data } = await api.get<string[]>(ORPHAN_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
 
 export const useOrphanedResources = () => {
   return useQuery({
-    queryKey: AdminQueryKeys.OphanedResourcesQueryKey,
-    queryFn: ({ signal }) => getOrphans({ baseURL: environment.baseUrl, signal })
+    queryKey: AdminQueryKeys.OrphanedResourcesQueryKey,
+    queryFn: ({ signal }) => getOrphans({ signal })
   })
 }

--- a/seta-react/src/api/admin/query-keys.ts
+++ b/seta-react/src/api/admin/query-keys.ts
@@ -5,7 +5,7 @@ export class AdminQueryKeys {
 
   public static readonly ResourceRequestsQueryKey = ['admin-pending-resource-requests']
 
-  public static readonly OphanedCommunitiesQueryKey = ['admin-orphaned-communities']
+  public static readonly OrphanedCommunitiesQueryKey = ['admin-orphaned-communities']
 
-  public static readonly OphanedResourcesQueryKey = ['admin-orphaned-resources']
+  public static readonly OrphanedResourcesQueryKey = ['admin-orphaned-resources']
 }

--- a/seta-react/src/api/admin/resource-requests.ts
+++ b/seta-react/src/api/admin/resource-requests.ts
@@ -7,12 +7,15 @@ import type { ResourceChangeRequest, RequestStatus } from '~/types/admin/change-
 
 import { AdminQueryKeys } from './query-keys'
 
-const RESOUCE_REQUESTS_API_PATH = '/admin/resources/change-requests'
+const RESOURCE_REQUESTS_API_PATH = '/admin/resources/change-requests'
 
 const getPendingRequests = async (
   config?: AxiosRequestConfig
 ): Promise<ResourceChangeRequest[]> => {
-  const { data } = await api.get<ResourceChangeRequest[]>(RESOUCE_REQUESTS_API_PATH, config)
+  const { data } = await api.get<ResourceChangeRequest[]>(RESOURCE_REQUESTS_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
@@ -20,7 +23,7 @@ const getPendingRequests = async (
 export const useResourcePendingRequests = () => {
   return useQuery({
     queryKey: AdminQueryKeys.ResourceRequestsQueryKey,
-    queryFn: ({ signal }) => getPendingRequests({ baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getPendingRequests({ signal })
   })
 }
 

--- a/seta-react/src/api/admin/users.ts
+++ b/seta-react/src/api/admin/users.ts
@@ -23,7 +23,11 @@ const getUserInfos = async (
       }
     : undefined
 
-  const { data } = await api.get<SetaUserInfo[]>(USER_INFOS_API_PATH, { params, ...config })
+  const { data } = await api.get<SetaUserInfo[]>(USER_INFOS_API_PATH, {
+    params,
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
@@ -31,7 +35,6 @@ const getUserInfos = async (
 export const useActiveUserInfos = () => {
   return useQuery({
     queryKey: queryKey.userInfos(AccountStatus.Active),
-    queryFn: ({ signal }) =>
-      getUserInfos(AccountStatus.Active, { baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getUserInfos(AccountStatus.Active, { signal })
   })
 }

--- a/seta-react/src/api/search/library.ts
+++ b/seta-react/src/api/search/library.ts
@@ -1,0 +1,155 @@
+import type { QueryKey } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { AxiosRequestConfig } from 'axios'
+
+import { mockRawLibraryItems } from '~/api/search/mocks'
+import type { LibraryItemRaw } from '~/types/library/library-item'
+
+export type LibraryResponse = {
+  items: LibraryItemRaw[]
+}
+
+export type NewFolderResponse = {
+  item: LibraryItemRaw
+}
+
+export type SaveDocumentsPayload = {
+  parentId: string | null
+  documents: {
+    documentId: string
+    title: string
+    link?: string
+  }[]
+}
+
+export type CreateNewFolderPayload = {
+  parentId: string | null
+  title: string
+}
+
+const mockData = [...mockRawLibraryItems]
+
+export const libraryQueryKey: QueryKey = ['library']
+
+const getLibraryItems = async (config?: AxiosRequestConfig): Promise<LibraryResponse> =>
+  // TODO: Replace with real API call
+  new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        items: [...mockData]
+      })
+    }, 500)
+  })
+
+export const useLibrary = () => {
+  return useQuery({
+    queryKey: libraryQueryKey,
+    queryFn: getLibraryItems
+  })
+}
+
+const getNextId = (data: LibraryItemRaw[]) =>
+  1 +
+  data.reduce((acc, { id }) => {
+    const idNumber = parseInt(id)
+
+    return idNumber > acc ? idNumber : acc
+  }, 0)
+
+// Returns the library after saving the documents
+const saveDocuments = async (
+  { parentId, documents }: SaveDocumentsPayload,
+  config?: AxiosRequestConfig
+): Promise<LibraryResponse> => {
+  // TODO: Replace the code below with the real API call
+
+  const rawData = mockData
+  const nextId = getNextId(rawData)
+
+  if (!parentId) {
+    const rootItems = rawData.filter(item => !item.parentId)
+    const lastItem = rootItems[rootItems.length - 1]
+
+    rawData.push(
+      ...documents.map<LibraryItemRaw>(({ documentId, title, link }, index) => ({
+        id: `${nextId + index}`,
+        order: lastItem.order + 1,
+        parentId: null,
+        type: 'document',
+        title,
+        documentId,
+        link
+      }))
+    )
+  } else {
+    rawData.push(
+      ...documents.map<LibraryItemRaw>(({ documentId, title, link }, index) => ({
+        id: `${nextId + index}`,
+        order: 0,
+        parentId,
+        type: 'document',
+        title,
+        documentId,
+        link
+      }))
+    )
+  }
+
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        items: rawData
+      })
+    }, 500)
+  })
+}
+
+export const useSaveDocuments = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: saveDocuments,
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: libraryQueryKey })
+    }
+  })
+}
+
+const createNewFolder = async (
+  { parentId, title }: CreateNewFolderPayload,
+  config?: AxiosRequestConfig
+): Promise<NewFolderResponse> => {
+  const rawData = mockData
+  const nextId = getNextId(rawData)
+
+  const newFolder: LibraryItemRaw = {
+    id: `${nextId}`,
+    order: -1,
+    parentId,
+    type: 'folder',
+    title
+  }
+
+  rawData.push(newFolder)
+
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        item: newFolder
+      })
+    }, 500)
+  })
+}
+
+export const useCreateNewFolder = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createNewFolder,
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: libraryQueryKey })
+    }
+  })
+}

--- a/seta-react/src/api/search/mocks.ts
+++ b/seta-react/src/api/search/mocks.ts
@@ -1,0 +1,143 @@
+import type { LibraryItemRaw } from '~/types/library/library-item'
+
+export const mockRawLibraryItems: LibraryItemRaw[] = [
+  {
+    id: '1',
+    parentId: null,
+    type: 'folder',
+    title: 'Environment',
+    order: 0
+  },
+  {
+    id: '2',
+    parentId: '1',
+    type: 'document',
+    documentId: 'doc1',
+    link: 'https://www.google.com',
+    title: 'Cities',
+    order: 0
+  },
+  {
+    id: '3',
+    parentId: '1',
+    type: 'folder',
+    title: 'Wildlife',
+    order: 1
+  },
+  {
+    id: '4',
+    parentId: '3',
+    type: 'folder',
+    title: 'North Europe',
+    order: 0
+  },
+  {
+    id: '5',
+    parentId: '4',
+    type: 'document',
+    documentId: 'doc3',
+    link: 'https://www.google.com',
+    title: 'Norway',
+    order: 0
+  },
+  {
+    id: '6',
+    parentId: '4',
+    type: 'document',
+    documentId: 'doc4',
+    link: 'https://www.google.com',
+    title: 'Sweden',
+    order: 1
+  },
+  {
+    id: '7',
+    parentId: '4',
+    type: 'document',
+    documentId: 'doc5',
+    link: 'https://www.google.com',
+    title: 'Finland',
+    order: 2
+  },
+  {
+    id: '8',
+    parentId: '4',
+    type: 'document',
+    documentId: 'doc6',
+    link: 'https://www.google.com',
+    title: 'Denmark',
+    order: 3
+  },
+  {
+    id: '9',
+    parentId: '3',
+    type: 'folder',
+    title: 'Lakes',
+    order: 1
+  },
+  {
+    id: '10',
+    parentId: '9',
+    type: 'document',
+    documentId: 'doc7',
+    link: 'https://www.google.com',
+    title: 'Lake Superior',
+    order: 0
+  },
+  {
+    id: '11',
+    parentId: '9',
+    type: 'document',
+    documentId: 'doc8',
+    link: 'https://www.google.com',
+    title: 'Lake Victoria',
+    order: 1
+  },
+  {
+    id: '12',
+    parentId: '3',
+    type: 'folder',
+    title: 'Mountains',
+    order: 2
+  },
+  {
+    id: '13',
+    parentId: '3',
+    type: 'folder',
+    title: 'Forests',
+    order: 3
+  },
+  {
+    id: '14',
+    parentId: null,
+    type: 'folder',
+    title: 'Animals',
+    order: 1
+  },
+  {
+    id: '15',
+    parentId: '14',
+    type: 'document',
+    documentId: 'doc9',
+    link: 'https://www.google.com',
+    title: 'The Lion',
+    order: 0
+  },
+  {
+    id: '16',
+    parentId: '14',
+    type: 'document',
+    documentId: 'doc10',
+    link: 'https://www.google.com',
+    title: 'The Tiger',
+    order: 1
+  },
+  {
+    id: '17',
+    parentId: null,
+    type: 'document',
+    documentId: 'doc11',
+    link: 'https://www.google.com',
+    title: 'Multimedia generator',
+    order: 2
+  }
+]

--- a/seta-react/src/components/ActionIconExtended/ActionIconExtended.tsx
+++ b/seta-react/src/components/ActionIconExtended/ActionIconExtended.tsx
@@ -1,0 +1,167 @@
+import type { ComponentProps, MouseEventHandler, ReactNode } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
+import { Transition, type ActionIcon } from '@mantine/core'
+
+import type { Color, Variant } from '~/types/lib-props'
+
+import * as S from './styles'
+
+type Variants = {
+  variant: Variant
+  activeVariant?: Variant
+  hoverVariant?: Variant
+  toggledVariant?: Variant
+}
+
+type Colors = {
+  color: Color
+  activeColor?: Color
+  hoverColor?: Color
+  toggledColor?: Color
+}
+
+const getCurrentVariant = (
+  isActive: boolean | undefined,
+  isToggled: boolean | undefined,
+  { variant, activeVariant, hoverVariant, toggledVariant }: Variants
+): Variant =>
+  isToggled
+    ? toggledVariant ?? hoverVariant ?? variant
+    : isActive
+    ? activeVariant ?? variant
+    : variant
+
+const getCurrentColor = (
+  isActive: boolean | undefined,
+  isToggled: boolean | undefined,
+  { color, activeColor, hoverColor, toggledColor }: Colors
+): Color =>
+  isToggled ? toggledColor ?? hoverColor ?? color : isActive ? activeColor ?? color : color
+
+const getHoverColor = (
+  isToggled: boolean | undefined,
+  { color, hoverColor, toggledColor }: Colors
+): Color => (isToggled ? toggledColor ?? hoverColor ?? color : hoverColor ?? color)
+
+type Props = ComponentProps<typeof ActionIcon<'button'>> & {
+  hoverVariant?: Variant
+  hoverColor?: Color
+  activeVariant?: Variant
+  activeColor?: Color
+  isActive?: boolean
+  toggledVariant?: Variant
+  toggledColor?: Color
+  isToggleButton?: boolean
+  toggled?: boolean
+  toggledIcon?: ReactNode
+  onToggle?: (toggled: boolean) => void
+}
+
+/**
+ * A wrapper around ActionIcon that changes its variant and color on hover and active states.
+ * It also supports toggling.
+ */
+const ActionIconExtended = forwardRef<HTMLButtonElement, Props>(
+  (
+    {
+      variant,
+      hoverVariant,
+      color,
+      hoverColor,
+      activeVariant,
+      activeColor,
+      isActive,
+      toggledColor,
+      toggledVariant,
+      toggled,
+      isToggleButton = toggled !== undefined,
+      toggledIcon,
+      onToggle,
+      onClick,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [isToggled, setIsToggled] = useState(toggled ?? false)
+
+    const colors: Colors = {
+      color,
+      activeColor,
+      hoverColor,
+      toggledColor
+    }
+
+    const currentVariant = getCurrentVariant(isActive, isToggled, {
+      variant,
+      activeVariant,
+      hoverVariant,
+      toggledVariant
+    })
+
+    const currentColor = getCurrentColor(isActive, isToggled, colors)
+    const hoveredColor = getHoverColor(isToggled, colors)
+
+    const toggle = () => setIsToggled(prev => !prev)
+
+    useEffect(() => {
+      if (isToggleButton) {
+        setIsToggled(toggled ?? false)
+      }
+    }, [isToggleButton, toggled])
+
+    const handleClick: MouseEventHandler<HTMLButtonElement> = e => {
+      e.stopPropagation()
+
+      if (isToggleButton) {
+        toggle()
+        onToggle?.(!isToggled)
+      }
+
+      onClick?.(e)
+    }
+
+    const content = isToggleButton ? (
+      <Transition mounted={!isToggled} transition="scale">
+        {styles => (
+          <div css={S.iconWrapper} style={styles}>
+            {children}
+          </div>
+        )}
+      </Transition>
+    ) : (
+      children
+    )
+
+    const toggledContent = isToggleButton && (
+      <Transition mounted={isToggled} transition="scale">
+        {styles => (
+          <div css={S.iconWrapper} style={styles}>
+            {toggledIcon}
+          </div>
+        )}
+      </Transition>
+    )
+
+    return (
+      <S.StyledActionIcon
+        ref={ref}
+        {...props}
+        className="seta-ActionIconExtended-root"
+        variant={currentVariant}
+        color={currentColor}
+        onClick={handleClick}
+        data-toggled={isToggled || undefined}
+        $hoverVariant={hoverVariant ?? currentVariant}
+        $hoverColor={hoveredColor ?? currentColor}
+        $toggledVariant={toggledVariant ?? hoverVariant ?? currentVariant}
+        $toggledColor={toggledColor ?? hoveredColor ?? currentColor}
+      >
+        {content}
+        {toggledContent}
+      </S.StyledActionIcon>
+    )
+  }
+)
+
+export default ActionIconExtended

--- a/seta-react/src/components/ActionIconExtended/index.ts
+++ b/seta-react/src/components/ActionIconExtended/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ActionIconExtended'
+export * from './ActionIconExtended'

--- a/seta-react/src/components/ActionIconExtended/styles.ts
+++ b/seta-react/src/components/ActionIconExtended/styles.ts
@@ -1,0 +1,77 @@
+import { css } from '@emotion/react'
+import styled from '@emotion/styled'
+import type { ActionIconProps } from '@mantine/core'
+import { ActionIcon, createPolymorphicComponent } from '@mantine/core'
+
+import type { Color, Variant } from '~/types/lib-props'
+import { transientProps } from '~/utils/styled-utils'
+
+type Props = ActionIconProps & {
+  $hoverColor: Color
+  $hoverVariant?: Variant
+  $toggledColor?: Color
+  $toggledVariant?: Variant
+}
+
+const _StyledActionIcon = styled(
+  ActionIcon,
+  transientProps
+)<Props>(
+  ({ theme, variant, color, $hoverVariant, $hoverColor, $toggledColor, $toggledVariant }) => {
+    const variantValue = variant?.toString() ?? 'subtle'
+
+    const hoverColors = theme.fn.variant({
+      variant: $hoverVariant?.toString() ?? variantValue,
+      color: $hoverColor ?? color
+    })
+
+    const toggledColors = theme.fn.variant({
+      variant:
+        $toggledVariant === 'outline' ? 'light' : $toggledVariant?.toString() ?? variantValue,
+      color: $toggledColor ?? color
+    })
+
+    const baseTransition = `color 200ms ${theme.transitionTimingFunction},
+      background-color 200ms ${theme.transitionTimingFunction},
+      opacity 200ms ${theme.transitionTimingFunction},
+      visibility 200ms ${theme.transitionTimingFunction},
+      margin 200ms ${theme.transitionTimingFunction},
+      width 200ms ${theme.transitionTimingFunction}`
+
+    return {
+      position: 'relative',
+
+      '&:not(:focus)': {
+        transition: baseTransition
+      },
+
+      '&:focus': {
+        transition: `outline-color 100ms ease, outline-offset 100ms ease, ${baseTransition}`
+      },
+
+      '&:hover': {
+        color: hoverColors.color,
+        backgroundColor: hoverColors.background
+      },
+
+      '&[data-toggled]:not(:hover)': {
+        backgroundColor: toggledColors.background
+      }
+    }
+  }
+)
+
+// ActionIcon is a polymorphic component, so we need to use `createPolymorphicComponent` to properly type it.
+// See https://mantine.dev/core/action-icon/#polymorphic-component and https://mantine.dev/styles/styled/#polymorphic-components
+export const StyledActionIcon = createPolymorphicComponent<'button', Props>(_StyledActionIcon)
+
+export const iconWrapper = css`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/seta-react/src/components/ActionIconPopover/ActionIconPopover.tsx
+++ b/seta-react/src/components/ActionIconPopover/ActionIconPopover.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { Popover, type PopoverProps } from '@mantine/core'
+
+import type { Action } from '~/components/ActionsGroup'
+import ColoredActionIcon from '~/components/ColoredActionIcon'
+
+import type { ClassNameProp } from '~/types/children-props'
+
+export type ActionWithPopover = Pick<
+  Action,
+  'icon' | 'color' | 'loading' | 'disabled' | 'tooltip' | 'onClick'
+> & {
+  active?: boolean
+}
+
+type Props = {
+  action: ActionWithPopover
+} & PopoverProps &
+  ClassNameProp
+
+const ActionIconPopover = ({
+  action,
+  opened,
+  children,
+  className,
+  onChange,
+  ...popoverProps
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(opened)
+
+  const { icon, tooltip, active, onClick, color, ...actionProps } = action
+
+  const handleIconClick = () => {
+    setIsOpen(prev => !prev)
+    onClick?.()
+  }
+
+  const handleChange = (open: boolean) => {
+    setIsOpen(open)
+    onChange?.(open)
+  }
+
+  useEffect(() => {
+    setIsOpen(opened)
+  }, [opened])
+
+  // TODO: Add a tooltip to the popover target
+
+  return (
+    <Popover
+      shadow="md"
+      position="bottom-end"
+      opened={isOpen}
+      onChange={handleChange}
+      {...popoverProps}
+    >
+      <Popover.Target>
+        <ColoredActionIcon
+          color={color}
+          activeColor={color}
+          activeVariant="filled"
+          isActive={isOpen || active}
+          onClick={handleIconClick}
+          {...actionProps}
+        >
+          {icon}
+        </ColoredActionIcon>
+      </Popover.Target>
+
+      <Popover.Dropdown className={className}>{children}</Popover.Dropdown>
+    </Popover>
+  )
+}
+
+export default ActionIconPopover

--- a/seta-react/src/components/ActionIconPopover/index.ts
+++ b/seta-react/src/components/ActionIconPopover/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActionIconPopover'

--- a/seta-react/src/components/ActionsGroup/ActionsGroup.tsx
+++ b/seta-react/src/components/ActionsGroup/ActionsGroup.tsx
@@ -1,0 +1,100 @@
+import { useMemo, type ReactElement } from 'react'
+import { Group, Tooltip, clsx } from '@mantine/core'
+
+import ColoredActionIcon from '~/components/ColoredActionIcon/ColoredActionIcon'
+
+import type { ClassNameProp } from '~/types/children-props'
+import type { Color } from '~/types/lib-props'
+
+import * as S from './styles'
+
+export type Action = {
+  name: string
+  icon: ReactElement
+  color?: Color
+  disabled?: boolean
+  loading?: boolean
+  tooltip?: string
+  toggleable?: boolean
+  toggled?: boolean
+  toggledColor?: Color
+  toggledIcon?: ReactElement
+  toggledTooltip?: string
+  skip?: boolean
+  onClick?: () => void
+  onToggle?: (toggled: boolean) => void
+}
+
+type Props = {
+  actions: Action[]
+  isActive?: boolean
+  noTransition?: boolean
+} & ClassNameProp
+
+const ActionsGroup = ({ className, actions, isActive, noTransition }: Props) => {
+  const availableActions = useMemo(() => actions.filter(action => !action.skip), [actions])
+
+  const hasMultipleTooltips = useMemo(
+    () => availableActions.some(action => action.tooltip),
+    [availableActions]
+  )
+
+  const classes = clsx(className, 'seta-ActionsGroup-root')
+  const rootStyles = [S.root, noTransition && S.noTransition]
+
+  const actionsElements = availableActions.map(action => {
+    const {
+      name,
+      icon,
+      color,
+      tooltip,
+      toggleable,
+      toggled,
+      toggledTooltip,
+      skip: _, // Exclude from `rest`
+      ...rest
+    } = action
+
+    const actionIcon = (
+      <ColoredActionIcon
+        key={tooltip ? undefined : name}
+        color={color}
+        isToggleButton={toggleable}
+        toggled={toggled}
+        isActive={isActive}
+        data-action={name}
+        {...rest}
+      >
+        {icon}
+      </ColoredActionIcon>
+    )
+
+    const tooltipLabel = toggled ? toggledTooltip ?? tooltip : tooltip
+
+    return tooltip ? (
+      <Tooltip key={name} label={tooltipLabel}>
+        {actionIcon}
+      </Tooltip>
+    ) : (
+      actionIcon
+    )
+  })
+
+  const content = hasMultipleTooltips ? (
+    <Tooltip.Group openDelay={300} closeDelay={200}>
+      {actionsElements}
+    </Tooltip.Group>
+  ) : (
+    actionsElements
+  )
+
+  return (
+    <div className={classes} data-actions>
+      <Group css={rootStyles} align="center" spacing="xs">
+        {content}
+      </Group>
+    </div>
+  )
+}
+
+export default ActionsGroup

--- a/seta-react/src/components/ActionsGroup/index.ts
+++ b/seta-react/src/components/ActionsGroup/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ActionsGroup'
+export * from './ActionsGroup'

--- a/seta-react/src/components/ActionsGroup/styles.ts
+++ b/seta-react/src/components/ActionsGroup/styles.ts
@@ -1,0 +1,10 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  padding: 6px;
+  transition: all 200ms ${theme.transitionTimingFunction};
+`
+
+export const noTransition = css`
+  transition: none;
+`

--- a/seta-react/src/components/AppRouter/components/RequireAuth.tsx
+++ b/seta-react/src/components/AppRouter/components/RequireAuth.tsx
@@ -1,15 +1,20 @@
+import type { ReactElement } from 'react'
 import { Flex, Loader } from '@mantine/core'
 import { Navigate } from 'react-router-dom'
 
 import { useCurrentUser } from '~/contexts/user-context'
-import type { AllowedRolesAndChildrenProps } from '~/types/children-props'
 import type { UserRole } from '~/types/user'
 
 // TODO: Get this from an environment variable
 const AUTH_PATH = '/login?redirect=' + window.location.pathname
 const HOME_PATH = '/'
 
-const RequireAuth = ({ children, allowedRoles }: AllowedRolesAndChildrenProps) => {
+type Props = {
+  allowedRoles?: UserRole[]
+  children: ReactElement
+}
+
+const RequireAuth = ({ children, allowedRoles }: Props) => {
   const { user, isLoading } = useCurrentUser()
 
   if (isLoading) {

--- a/seta-react/src/components/CancelButton/CancelButton.tsx
+++ b/seta-react/src/components/CancelButton/CancelButton.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react'
+import { Button } from '@mantine/core'
+
+type Props = Omit<ComponentProps<typeof Button<'button'>>, 'color' | 'variant'>
+
+const CancelButton = ({ children = 'Cancel', ...props }: Props) => {
+  return (
+    <Button color="gray.7" variant="light" {...props}>
+      {children}
+    </Button>
+  )
+}
+
+export default CancelButton

--- a/seta-react/src/components/CancelButton/index.ts
+++ b/seta-react/src/components/CancelButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CancelButton'

--- a/seta-react/src/components/ChevronToggleIcon/ChevronToggleIcon.tsx
+++ b/seta-react/src/components/ChevronToggleIcon/ChevronToggleIcon.tsx
@@ -3,47 +3,54 @@ import type { TextProps } from '@mantine/core'
 import { Text } from '@mantine/core'
 import { FaChevronDown } from 'react-icons/fa'
 
+import type { ClassNameProp } from '~/types/children-props'
+
 import * as S from './styles'
 
-enum Orientation {
-  UP = 'up',
-  DOWN = 'down',
-  LEFT = 'left',
-  RIGHT = 'right'
-}
+type Orientation = 'up' | 'down' | 'left' | 'right'
 
 const startStyles: Record<Orientation, SerializedStyles> = {
-  [Orientation.UP]: S.upStart,
-  [Orientation.DOWN]: S.downStart,
-  [Orientation.LEFT]: S.leftStart,
-  [Orientation.RIGHT]: S.rightStart
+  up: S.upStart,
+  down: S.downStart,
+  left: S.leftStart,
+  right: S.rightStart
 }
 
 const endStyles: Record<Orientation, SerializedStyles> = {
-  [Orientation.UP]: S.upEnd,
-  [Orientation.DOWN]: S.downEnd,
-  [Orientation.LEFT]: S.leftEnd,
-  [Orientation.RIGHT]: S.rightEnd
+  up: S.upEnd,
+  down: S.downEnd,
+  left: S.leftEnd,
+  right: S.rightEnd
 }
 
-type Props = {
+type Props = ClassNameProp & {
   toggled: boolean
-  startOrientation?: Orientation
-  endOrientation?: Orientation
+  start?: Orientation
+  end?: Orientation
   color?: TextProps['color']
+  size?: TextProps['size']
 }
 
 const ChevronToggleIcon = ({
   toggled,
   color = 'gray.7',
-  startOrientation = Orientation.DOWN,
-  endOrientation = Orientation.UP
+  start = 'down',
+  end = 'up',
+  size,
+  className
 }: Props) => {
-  const startStyle = startStyles[startOrientation]
-  const endStyle = endStyles[endOrientation]
+  const startStyle = startStyles[start]
+  const endStyle = endStyles[end]
 
   return (
-    <Text css={[S.chevron, startStyle, endStyle]} data-toggled={toggled} color={color} lh={1}>
+    <Text
+      className={className}
+      css={[S.chevron, startStyle, endStyle]}
+      data-toggled={toggled}
+      color={color}
+      size={size}
+      lh={1}
+    >
       <FaChevronDown />
     </Text>
   )

--- a/seta-react/src/components/ChevronToggleIcon/styles.ts
+++ b/seta-react/src/components/ChevronToggleIcon/styles.ts
@@ -38,11 +38,11 @@ export const leftEnd = css`
 `
 
 export const rightStart = css`
-  transform: rotate(270deg);
+  transform: rotate(-90deg);
 `
 
 export const rightEnd = css`
   &[data-toggled='true'] {
-    transform: rotate(270deg);
+    transform: rotate(-90deg);
   }
 `

--- a/seta-react/src/components/ColoredActionIcon/ColoredActionIcon.tsx
+++ b/seta-react/src/components/ColoredActionIcon/ColoredActionIcon.tsx
@@ -1,0 +1,42 @@
+import type { ComponentProps } from 'react'
+import { forwardRef } from 'react'
+
+import ActionIconExtended from '~/components/ActionIconExtended'
+
+import type { Color } from '~/types/lib-props'
+
+type Props = Omit<ComponentProps<typeof ActionIconExtended>, 'hoverColor' | 'hoverVariant'> & {
+  toggledColor?: Color
+}
+
+const ColoredActionIcon = forwardRef<HTMLButtonElement, Props>(
+  (
+    {
+      color,
+      toggledColor,
+      activeVariant = 'light',
+      activeColor = `${color}.4`,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <ActionIconExtended
+        ref={ref}
+        color="gray.5"
+        activeColor={activeColor}
+        activeVariant={activeVariant}
+        hoverColor={color}
+        hoverVariant="filled"
+        toggledColor={toggledColor}
+        toggledVariant="outline"
+        {...props}
+      >
+        {children}
+      </ActionIconExtended>
+    )
+  }
+)
+
+export default ColoredActionIcon

--- a/seta-react/src/components/ColoredActionIcon/index.ts
+++ b/seta-react/src/components/ColoredActionIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColoredActionIcon'

--- a/seta-react/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/seta-react/src/components/ConfirmModal/ConfirmModal.tsx
@@ -2,6 +2,10 @@ import type { ReactNode } from 'react'
 import type { ButtonProps } from '@mantine/core'
 import { Button, Divider, Flex, Group, Modal, Stack, Text } from '@mantine/core'
 
+import CancelButton from '~/components/CancelButton/CancelButton'
+
+import * as S from './styles'
+
 type Props = {
   title?: ReactNode
   text: string
@@ -11,6 +15,8 @@ type Props = {
   confirmColor?: ButtonProps['color']
   loading?: boolean
   opened: boolean
+  withinPortal?: boolean
+  zIndex?: number
   onClose: () => void
   onConfirm: () => void
 }
@@ -22,6 +28,8 @@ const ConfirmModal = ({
   confirmLabel,
   confirmColor,
   loading,
+  withinPortal,
+  zIndex = 300,
   onConfirm,
   onClose,
   ...props
@@ -29,7 +37,16 @@ const ConfirmModal = ({
   const buttonColor: ButtonProps['color'] = confirmColor ?? 'blue'
 
   return (
-    <Modal centered size="auto" zIndex={300} withCloseButton={false} onClose={onClose} {...props}>
+    <Modal
+      centered
+      size="auto"
+      zIndex={zIndex}
+      withCloseButton={false}
+      withinPortal={withinPortal}
+      onClose={onClose}
+      css={S.root}
+      {...props}
+    >
       <Stack>
         <Flex align="center" justify="center" gap="xl" p="3rem">
           {icon}
@@ -46,12 +63,10 @@ const ConfirmModal = ({
         <Divider />
 
         <Group position="right" spacing="sm">
+          <CancelButton onClick={onClose} />
+
           <Button color={buttonColor} loading={loading} onClick={onConfirm}>
             {confirmLabel ?? 'Confirm'}
-          </Button>
-
-          <Button color="gray.8" variant="light" onClick={onClose}>
-            Cancel
           </Button>
         </Group>
       </Stack>

--- a/seta-react/src/components/ConfirmModal/styles.ts
+++ b/seta-react/src/components/ConfirmModal/styles.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react'
+
+export const root = css`
+  .seta-Modal-inner {
+    left: 0;
+  }
+`

--- a/seta-react/src/components/Page/styles.ts
+++ b/seta-react/src/components/Page/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 
-export const root: ThemedCSS = theme => css`
+export const root = css`
   padding: 3rem 0;
   flex: 1;
 
@@ -9,11 +9,10 @@ export const root: ThemedCSS = theme => css`
   }
 `
 
-export const pageWrapper: ThemedCSS = theme => css`
+export const pageWrapper = css`
   flex: 1;
 `
 
-export const contentWrapper: ThemedCSS = theme => css`
+export const contentWrapper = css`
   flex: 1;
-  /* padding-top: 2rem; */
 `

--- a/seta-react/src/components/PopupOverlay/PopupOverlay.tsx
+++ b/seta-react/src/components/PopupOverlay/PopupOverlay.tsx
@@ -1,0 +1,84 @@
+import { type ReactElement, cloneElement, useMemo, useState, useEffect } from 'react'
+import type { PopoverProps } from '@mantine/core'
+import { ActionIcon, Popover } from '@mantine/core'
+import { IconX } from '@tabler/icons-react'
+
+import * as S from './styles'
+
+type Props = {
+  target: ReactElement
+  open?: boolean
+  onOpenChange?: (value: boolean) => void
+} & Omit<PopoverProps, 'opened' | 'onChange'>
+
+const PopupOverlay = ({
+  target,
+  open,
+  defaultOpened,
+  shadow = 'md',
+  onOpenChange,
+  children,
+  ...props
+}: Props) => {
+  // TODO: Move this to a hook
+  const isControlled = open !== undefined
+
+  const [popupOpen, setPopupOpen] = useState(open ?? defaultOpened ?? false)
+
+  useEffect(() => {
+    if (isControlled) {
+      setPopupOpen(open)
+    }
+  }, [isControlled, open])
+
+  const handlePopupChange = (value: boolean) => {
+    if (!isControlled) {
+      setPopupOpen(false)
+    }
+
+    onOpenChange?.(value)
+  }
+
+  const closePopup = () => {
+    handlePopupChange(false)
+  }
+
+  // If the popup is not controlled, we need to add an onClick handler to the target
+  // because we're not using the Popover's built-in toggle functionality in that case.
+  const finalTarget = useMemo(
+    () =>
+      isControlled
+        ? target
+        : cloneElement(target, {
+            onClick: () => {
+              target.props.onClick?.()
+              setPopupOpen(prev => !prev)
+            }
+          }),
+    [isControlled, target]
+  )
+
+  return (
+    <Popover opened={popupOpen} onChange={handlePopupChange} shadow={shadow} {...props}>
+      <Popover.Target>{finalTarget}</Popover.Target>
+
+      <Popover.Dropdown css={S.popup}>
+        <div>
+          {children}
+
+          <ActionIcon
+            variant="light"
+            size="md"
+            radius="sm"
+            css={S.closeButton}
+            onClick={closePopup}
+          >
+            <IconX size={20} strokeWidth={3} />
+          </ActionIcon>
+        </div>
+      </Popover.Dropdown>
+    </Popover>
+  )
+}
+
+export default PopupOverlay

--- a/seta-react/src/components/PopupOverlay/index.ts
+++ b/seta-react/src/components/PopupOverlay/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PopupOverlay'

--- a/seta-react/src/components/PopupOverlay/styles.ts
+++ b/seta-react/src/components/PopupOverlay/styles.ts
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react'
+
+const POPUP_HEIGHT = '500px'
+
+export const popup: ThemedCSS = theme => css`
+  display: flex;
+  border-color: ${theme.colors.gray[4]};
+  height: ${POPUP_HEIGHT};
+  padding: ${theme.spacing.sm};
+
+  .seta-Popover-arrow {
+    border-color: inherit;
+  }
+
+  & > div {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+`
+
+export const closeButton = css`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+`

--- a/seta-react/src/components/ScrollModal/ScrollModal.tsx
+++ b/seta-react/src/components/ScrollModal/ScrollModal.tsx
@@ -69,7 +69,7 @@ const ScrollModal = ({
   const titleEl = !!title && (
     <Flex css={{ flex: 1 }} pr="xs" justify="space-between">
       <Flex gap="sm" align="center">
-        <div css={S.icon}>{icon}</div>
+        {icon && <div css={S.icon}>{icon}</div>}
 
         <Text size="lg" fw={500} color="gray.8">
           {title}

--- a/seta-react/src/components/ScrollModal/styles.ts
+++ b/seta-react/src/components/ScrollModal/styles.ts
@@ -41,6 +41,10 @@ export const modalStyles = createStyles(theme => ({
 }))
 
 export const root = css`
+  .seta-Modal-inner {
+    left: 0;
+  }
+
   &[data-fullscreen='true'] {
     .seta-Modal-body {
       max-height: 100vh;

--- a/seta-react/src/components/Sidebar/styles.ts
+++ b/seta-react/src/components/Sidebar/styles.ts
@@ -11,11 +11,16 @@ export const sidebar: ThemedCSS = theme => css`
   top: 0;
   margin: -3rem 0;
   min-width: 25rem;
+  max-width: 25rem;
   max-height: 100vh;
   height: auto;
   flex: 1;
   border-color: ${theme.colors.gray[2]};
   background-color: ${theme.fn.rgba(theme.colors.gray[0], 1)};
+
+  .seta-ScrollArea-viewport > div {
+    display: block !important;
+  }
 `
 
 export const mainSection: ThemedCSS = theme => css`

--- a/seta-react/src/components/Tabs/Tabs.tsx
+++ b/seta-react/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,89 @@
+import type { ForwardedRef, ReactElement } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import type { TabsListProps } from '@mantine/core'
+import { Tabs as MantineTabs } from '@mantine/core'
+import { useScrollIntoView } from '@mantine/hooks'
+
+import type { ClassAndChildrenProps } from '~/types/children-props'
+
+import { CurrentTabProvider } from './contexts/tabs-context'
+import * as S from './styles'
+
+const SCROLL_DELAY = 0
+
+export type TabsProps = {
+  panels: ReactElement
+  defaultValue?: string
+  position?: TabsListProps['position']
+  tabsRef?: ForwardedRef<HTMLDivElement>
+  noScroll?: boolean
+  onTabChange?: (value: string) => void
+} & ClassAndChildrenProps
+
+const Tabs = ({
+  panels,
+  defaultValue,
+  className,
+  tabsRef,
+  noScroll,
+  onTabChange,
+  children,
+  ...rest
+}: TabsProps) => {
+  const [activeTab, setActiveTab] = useState(defaultValue ?? null)
+
+  const prevTabRef = useRef<string | undefined>(defaultValue)
+  const timeoutRef = useRef<number | undefined>(undefined)
+
+  const { scrollIntoView, targetRef } = useScrollIntoView<HTMLDivElement>({
+    duration: 100,
+    offset: 16
+  })
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const handleTabChange = (value: string) => {
+    if (!noScroll) {
+      timeoutRef.current = window.setTimeout(() => {
+        scrollIntoView()
+      }, SCROLL_DELAY)
+    }
+
+    if (prevTabRef.current === value) {
+      return
+    }
+
+    setActiveTab(value)
+
+    prevTabRef.current = value
+
+    onTabChange?.(value)
+  }
+
+  return (
+    <MantineTabs
+      css={S.root}
+      ref={targetRef}
+      className={className}
+      variant="outline"
+      value={activeTab}
+      onTabChange={handleTabChange}
+      {...rest}
+    >
+      <CurrentTabProvider value={activeTab}>
+        <MantineTabs.List ref={tabsRef} position="center">
+          {children}
+        </MantineTabs.List>
+
+        {panels}
+      </CurrentTabProvider>
+    </MantineTabs>
+  )
+}
+
+export default Tabs

--- a/seta-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/seta-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement, ReactNode } from 'react'
+import type {
+  DefaultMantineColor,
+  MantineNumberSize,
+  SpacingValue,
+  SystemProp,
+  ThemeIconProps
+} from '@mantine/core'
+import { Group, Tabs, ThemeIcon } from '@mantine/core'
+
+import { useCurrentTab } from '~/components/Tabs/contexts/tabs-context'
+
+import * as S from './styles'
+
+type Props = {
+  value: string
+  icon?: ReactElement
+  color?: DefaultMantineColor
+  label: ReactNode
+  spacing?: MantineNumberSize
+  padding?: SystemProp<SpacingValue>
+}
+
+const Tab = ({ value, icon, label, padding, color = 'gray.5', spacing = 'sm' }: Props) => {
+  const isActive = useCurrentTab() === value
+
+  const iconVariant: ThemeIconProps['variant'] = isActive ? 'filled' : 'outline'
+  const iconColor: DefaultMantineColor = isActive ? color : 'gray.5'
+
+  const iconEl = icon && (
+    <ThemeIcon css={S.iconWrapper} variant={iconVariant} color={iconColor}>
+      {icon}
+    </ThemeIcon>
+  )
+
+  return (
+    <Tabs.Tab value={value}>
+      <Group spacing={spacing} p={padding}>
+        {iconEl}
+        {label}
+      </Group>
+    </Tabs.Tab>
+  )
+}
+
+export default Tab

--- a/seta-react/src/components/Tabs/components/Tab/index.ts
+++ b/seta-react/src/components/Tabs/components/Tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Tab'

--- a/seta-react/src/components/Tabs/components/Tab/styles.ts
+++ b/seta-react/src/components/Tabs/components/Tab/styles.ts
@@ -1,0 +1,5 @@
+import { css } from '@emotion/react'
+
+export const iconWrapper: ThemedCSS = theme => css`
+  font-size: ${theme.fontSizes.xl};
+`

--- a/seta-react/src/components/Tabs/components/TabPanel/TabPanel.tsx
+++ b/seta-react/src/components/Tabs/components/TabPanel/TabPanel.tsx
@@ -1,0 +1,19 @@
+import { Tabs } from '@mantine/core'
+
+import type { ClassAndChildrenProps } from '~/types/children-props'
+
+import * as S from './styles'
+
+type Props = {
+  value: string
+} & ClassAndChildrenProps
+
+const TabPanel = ({ value, className, children }: Props) => {
+  return (
+    <Tabs.Panel css={S.root} value={value} className={className}>
+      <div css={S.content}>{children}</div>
+    </Tabs.Panel>
+  )
+}
+
+export default TabPanel

--- a/seta-react/src/components/Tabs/components/TabPanel/index.ts
+++ b/seta-react/src/components/Tabs/components/TabPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TabPanel'

--- a/seta-react/src/components/Tabs/components/TabPanel/styles.ts
+++ b/seta-react/src/components/Tabs/components/TabPanel/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react'
+
+import { CONTENT_MAX_WIDTH } from '~/styles'
+
+export const root: ThemedCSS = theme => css`
+  max-width: ${CONTENT_MAX_WIDTH};
+  position: relative;
+  padding: ${theme.spacing.lg} 0;
+  margin-left: auto;
+  margin-right: auto;
+`
+
+export const content = css`
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`

--- a/seta-react/src/components/Tabs/contexts/tabs-context.tsx
+++ b/seta-react/src/components/Tabs/contexts/tabs-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react'
+
+import type { PropsWithChildren } from '~/types/children-props'
+
+type CurrentTabContextProps = {
+  value: string | null
+}
+
+const CurrentTabContext = createContext<CurrentTabContextProps | undefined>(undefined)
+
+export const CurrentTabProvider = ({
+  value,
+  children
+}: PropsWithChildren<CurrentTabContextProps>) => (
+  <CurrentTabContext.Provider value={{ value }}>{children}</CurrentTabContext.Provider>
+)
+
+export const useCurrentTab = () => {
+  const context = useContext(CurrentTabContext)
+
+  if (context === undefined) {
+    throw new Error('useCurrentTab must be used within a CurrentTabProvider')
+  }
+
+  return context.value
+}

--- a/seta-react/src/components/Tabs/index.ts
+++ b/seta-react/src/components/Tabs/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Tabs'
+export { default as Tab } from './components/Tab'
+export { default as TabPanel } from './components/TabPanel'

--- a/seta-react/src/components/Tabs/styles.ts
+++ b/seta-react/src/components/Tabs/styles.ts
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  .seta-Tabs-tabsList {
+    border-color: ${theme.colors.gray[4]};
+  }
+
+  .seta-Tabs-tab {
+    font-size: ${theme.fontSizes.md};
+    transition: border-color 0.2s ${theme.transitionTimingFunction},
+      color 0.2s ${theme.transitionTimingFunction};
+
+    .seta-Tabs-tabLabel {
+      color: ${theme.colors.dark[4]};
+    }
+
+    .seta-ThemeIcon-root {
+      transition: all 0.2s ${theme.transitionTimingFunction};
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+
+    &[data-active] {
+      border-color: ${theme.colors.gray[4]};
+      color: ${theme.colors.dark[9]};
+
+      .seta-Tabs-tabLabel {
+        color: ${theme.colors.dark[9]};
+      }
+    }
+
+    &:not([data-active]) {
+      border-color: transparent;
+
+      &:hover:not(:active) {
+        background-color: ${theme.colors.gray[0]};
+      }
+    }
+
+    & + .seta-Tabs-tab {
+      margin-left: ${theme.spacing.xs};
+    }
+  }
+`

--- a/seta-react/src/components/TogglePanel/TogglePanel.tsx
+++ b/seta-react/src/components/TogglePanel/TogglePanel.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react'
+import { Collapse, Group, clsx } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+
+import type { Action } from '~/components/ActionsGroup'
+import ActionsGroup from '~/components/ActionsGroup'
+import ChevronToggleIcon from '~/components/ChevronToggleIcon/ChevronToggleIcon'
+
+import type { ClassAndChildrenProps } from '~/types/children-props'
+
+import * as S from './styles'
+
+type Props = {
+  header: ReactNode
+  details?: ReactNode
+  actions?: Action[]
+  open?: boolean
+  onChange?: (open: boolean) => void
+} & ClassAndChildrenProps
+
+/**
+ * A panel that can be toggled open or closed.
+ *
+ * - The `header` prop is the element that can be clicked to toggle the panel open or closed.
+ * - The `details` prop is the element that is shown when the panel is open.
+ * - The `actions` are the optional actions that are shown on the right of the header.
+ * - The `children` are always shown, below the header.
+ */
+const TogglePanel = ({ className, header, actions, details, open, onChange, children }: Props) => {
+  const [detailsOpen, { toggle }] = useDisclosure(open)
+
+  const classes = clsx({ open: detailsOpen, className })
+
+  const hasDetails = !!details
+
+  const handleToggle = () => {
+    toggle()
+    onChange?.(!detailsOpen)
+  }
+
+  const toggleIcon = hasDetails && <ChevronToggleIcon toggled={detailsOpen} />
+
+  return (
+    <div css={S.root} className={classes}>
+      <div
+        css={S.header}
+        data-details={hasDetails || undefined}
+        data-open={detailsOpen || undefined}
+        onClick={handleToggle}
+      >
+        {header}
+
+        <Group spacing="xs">
+          {actions && <ActionsGroup actions={actions} isActive={detailsOpen} />}
+
+          {toggleIcon}
+        </Group>
+      </div>
+
+      {children}
+
+      {hasDetails && (
+        <Collapse css={S.details} in={detailsOpen}>
+          {details}
+        </Collapse>
+      )}
+    </div>
+  )
+}
+
+export default TogglePanel

--- a/seta-react/src/components/TogglePanel/index.ts
+++ b/seta-react/src/components/TogglePanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TogglePanel'

--- a/seta-react/src/components/TogglePanel/styles.ts
+++ b/seta-react/src/components/TogglePanel/styles.ts
@@ -1,0 +1,90 @@
+import { css } from '@emotion/react'
+
+const actionVisible = css`
+  visibility: visible;
+  opacity: 1;
+  pointer-events: all;
+  width: 1.75rem;
+  min-width: 1.75rem;
+`
+
+export const root: ThemedCSS = theme => css`
+  position: relative;
+
+  transition: padding-top 200ms ${theme.transitionTimingFunction},
+    padding-bottom 200ms ${theme.transitionTimingFunction};
+
+  .seta-ActionsGroup-root {
+    transition: all 200ms ${theme.transitionTimingFunction};
+
+    & .seta-ActionIcon-root {
+      visibility: hidden;
+      opacity: 0;
+      pointer-events: none;
+      width: 0;
+      min-width: 0;
+
+      &[data-toggled] {
+        ${actionVisible}
+      }
+    }
+  }
+
+  &:hover,
+  &.open {
+    .seta-ActionsGroup-root .seta-ActionIcon-root {
+      ${actionVisible}
+    }
+  }
+
+  &.open {
+    margin: 0 -${theme.spacing.sm};
+    padding: ${theme.spacing.sm};
+    border-radius: ${theme.radius.sm};
+    border: 1px solid ${theme.colors.gray[3]};
+    box-shadow: ${theme.shadows.xs};
+
+    [data-details] {
+      border-color: transparent !important;
+      transition: none !important;
+    }
+
+    .seta-ActionsGroup-root {
+      margin-right: ${theme.spacing.xs};
+      background-color: ${theme.white};
+    }
+  }
+`
+
+export const header: ThemedCSS = theme => css`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: ${theme.spacing.lg};
+
+  position: relative;
+
+  &[data-details] {
+    cursor: pointer;
+    margin: 0 -${theme.spacing.sm};
+    padding: 0 ${theme.spacing.sm};
+    border-radius: ${theme.radius.sm};
+    border: 1px solid transparent;
+    transition: border-color 200ms ${theme.transitionTimingFunction};
+
+    &:hover {
+      border-color: ${theme.colors.gray[3]};
+    }
+
+    &:active:not(:focus-within) {
+      transform: translateY(1px);
+    }
+  }
+`
+
+export const details: ThemedCSS = theme => css`
+  // Set the margin on the inner div to prevent the content from "jumping" when the details are toggled
+  & > div {
+    margin-top: ${theme.spacing.lg};
+  }
+`

--- a/seta-react/src/components/ToggleTransition/ToggleTransition.tsx
+++ b/seta-react/src/components/ToggleTransition/ToggleTransition.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react'
+import type { MantineTransition } from '@mantine/core'
+import { Transition } from '@mantine/core'
+
+import * as S from './styles'
+
+type Props = {
+  toggled?: boolean
+  toggledElement: ReactNode
+  children: ReactNode
+  transition?: MantineTransition
+  transitionIn?: MantineTransition
+  transitionOut?: MantineTransition
+  duration?: number
+  durationIn?: number
+  durationOut?: number
+}
+
+const ToggleTransition = ({
+  toggled = false,
+  toggledElement,
+  transition = 'scale',
+  transitionIn = transition,
+  transitionOut = transition,
+  duration,
+  durationIn = duration,
+  durationOut = duration,
+  children
+}: Props) => {
+  const content = (
+    <Transition mounted={!toggled} transition={transitionOut} duration={durationOut}>
+      {styles => (
+        <div css={S.element} style={styles}>
+          {children}
+        </div>
+      )}
+    </Transition>
+  )
+
+  const toggledContent = (
+    <Transition mounted={toggled} transition={transitionIn} duration={durationIn}>
+      {styles => (
+        <div css={S.element} style={styles}>
+          {toggledElement}
+        </div>
+      )}
+    </Transition>
+  )
+
+  return (
+    <div css={S.root}>
+      {content}
+      {toggledContent}
+    </div>
+  )
+}
+
+export default ToggleTransition

--- a/seta-react/src/components/ToggleTransition/index.ts
+++ b/seta-react/src/components/ToggleTransition/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ToggleTransition'

--- a/seta-react/src/components/ToggleTransition/styles.ts
+++ b/seta-react/src/components/ToggleTransition/styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react'
+
+export const root = css`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+`
+
+export const element = css`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/seta-react/src/components/UnderConstruction/styles.ts
+++ b/seta-react/src/components/UnderConstruction/styles.ts
@@ -14,20 +14,20 @@ export const label: ThemedCSS = theme => css`
   margin-bottom: calc(${theme.spacing.xl} * 1.5);
   color: ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2]};
 
-  [${theme.fn.smallerThan('sm')}]: {
+  [${theme.fn.smallerThan('sm')}] {
     font-size: ${rem(120)};
   }
 `
 
 export const title: ThemedCSS = theme => css`
-    font-family: Greycliff CF, ${theme.fontFamily};
-    text-align: 'center';
-    font-weight: 900;
-    font-size: ${rem(38)};
+  font-family: Greycliff CF, ${theme.fontFamily};
+  text-align: 'center';
+  font-weight: 900;
+  font-size: ${rem(38)};
 
-    [${theme.fn.smallerThan('sm')}]: {
-      font-size: ${rem(32)},
-    },
+  [${theme.fn.smallerThan('sm')}] {
+    font-size: ${rem(32)};
+  }
 `
 
 export const description: ThemedCSS = theme => css`

--- a/seta-react/src/components/UnderDevelopment/UnderDevelopment.tsx
+++ b/seta-react/src/components/UnderDevelopment/UnderDevelopment.tsx
@@ -1,0 +1,28 @@
+import type { MantineStyleSystemProps } from '@mantine/core'
+import { Alert, Text } from '@mantine/core'
+
+import type { Variant } from './constants'
+import { COLOR, ICON, TEXT, TITLE } from './constants'
+
+type Props = MantineStyleSystemProps & {
+  variant?: Variant
+  text?: string
+}
+
+const UnderDevelopment = ({
+  variant = 'under-development',
+  text = TEXT[variant],
+  ...props
+}: Props) => {
+  const icon = ICON[variant]
+  const color = COLOR[variant]
+  const title = TITLE[variant]
+
+  return (
+    <Alert icon={icon} color={color} radius="md" title={title} {...props}>
+      <Text color="dark.4">{text}</Text>
+    </Alert>
+  )
+}
+
+export default UnderDevelopment

--- a/seta-react/src/components/UnderDevelopment/constants.tsx
+++ b/seta-react/src/components/UnderDevelopment/constants.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import type { DefaultMantineColor } from '@mantine/core'
+import { IoIosInformationCircle, IoIosWarning } from 'react-icons/io'
+
+export type Variant = 'under-development' | 'coming-soon'
+
+export const TITLE: Record<Variant, string> = {
+  'under-development': 'Under development',
+  'coming-soon': 'Coming soon!'
+}
+
+export const TEXT: Record<Variant, string> = {
+  'under-development':
+    'This feature is under development and should be used for demo purposes only.',
+  'coming-soon': 'This feature will bee available soon.'
+}
+
+export const COLOR: Record<Variant, DefaultMantineColor> = {
+  'under-development': 'pink',
+  'coming-soon': 'blue'
+}
+
+export const ICON: Record<Variant, ReactNode> = {
+  'under-development': <IoIosWarning size={20} />,
+  'coming-soon': <IoIosInformationCircle size={20} />
+}

--- a/seta-react/src/components/UnderDevelopment/index.ts
+++ b/seta-react/src/components/UnderDevelopment/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UnderDevelopment'

--- a/seta-react/src/hooks/use-click-outside-rect.ts
+++ b/seta-react/src/hooks/use-click-outside-rect.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react'
+
+const DEFAULT_EVENTS = ['mousedown', 'touchstart']
+
+export type CloseType =
+  | 'outside-rect'
+  | 'outside-rect-x'
+  | 'outside-rect-y'
+  | 'outside-rect-x-above'
+  | 'outside-rect-x-below'
+
+const isPointerInsideRect = (
+  x: number,
+  y: number,
+  { left, right, top, bottom }: DOMRect,
+  closeType: CloseType = 'outside-rect'
+) => {
+  switch (closeType) {
+    case 'outside-rect':
+      return x >= left && x <= right && y >= top && y <= bottom
+
+    case 'outside-rect-x':
+      return x >= left && x <= right
+
+    case 'outside-rect-y':
+      return y >= top && y <= bottom
+
+    case 'outside-rect-x-above':
+      return x >= left && x <= right && y >= top
+
+    case 'outside-rect-x-below':
+      return x >= left && x <= right && y <= bottom
+
+    default:
+      return false
+  }
+}
+
+const getCoordinates = (event: Event) => {
+  if (event instanceof MouseEvent) {
+    return { x: event.clientX, y: event.clientY }
+  }
+
+  if (event instanceof TouchEvent) {
+    const { clientX, clientY } = event.touches[0]
+
+    return { x: clientX, y: clientY }
+  }
+
+  return { x: 0, y: 0 }
+}
+
+type Options = {
+  events?: string[]
+  closeType?: CloseType
+  disabled?: boolean
+}
+
+/**
+ * Use this hook to detect clicks outside of a given element's rect, with the option to specify the axis to ignore.
+ * @param handler The callback to be run
+ * @param option Options to customize the hook's behavior
+ * @returns A ref to be passed to the element to be tracked
+ */
+const useClickOutsideRect = <T extends HTMLElement = HTMLElement>(
+  handler: () => void,
+  { events = DEFAULT_EVENTS, closeType = 'outside-rect', disabled }: Options = {}
+) => {
+  const ref = useRef<T>(null)
+  const handlerRef = useRef(handler)
+
+  useEffect(() => {
+    if (disabled) {
+      return
+    }
+
+    const listener = (event: Event) => {
+      if (!ref.current) {
+        return
+      }
+
+      const rect = ref.current.getBoundingClientRect()
+      const { x, y } = getCoordinates(event)
+
+      const { target } = event
+
+      if (ref.current.contains(target as Node) || isPointerInsideRect(x, y, rect, closeType)) {
+        return
+      }
+
+      handlerRef.current()
+    }
+
+    events.forEach(event => {
+      document.addEventListener(event, listener)
+    })
+
+    return () => {
+      events.forEach(event => {
+        document.removeEventListener(event, listener)
+      })
+    }
+  }, [ref, events, disabled, closeType])
+
+  return ref
+}
+
+export default useClickOutsideRect

--- a/seta-react/src/hooks/use-min-value.ts
+++ b/seta-react/src/hooks/use-min-value.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns the value if it is greater than the minimum value, otherwise returns the minimum value
+ * @param value The value to check
+ * @param minValue The minimum value
+ */
+const useMinValue = (value: number, minValue: number) => (value < minValue ? minValue : value)
+
+export default useMinValue

--- a/seta-react/src/hooks/use-paginator.tsx
+++ b/seta-react/src/hooks/use-paginator.tsx
@@ -13,6 +13,7 @@ type Args = {
   resetPageDependencies?: unknown[]
   scrollDependencies?: unknown[]
   scrollOnPageChange?: boolean
+  scrollOffset?: number
   onPageChange: (page: number) => void
 }
 
@@ -46,6 +47,7 @@ const usePaginator = <TScrollable extends HTMLElement | null = null>({
   resetPageDependencies,
   scrollDependencies,
   scrollOnPageChange = true,
+  scrollOffset = 40,
   onPageChange
 }: Args) => {
   const {
@@ -54,7 +56,7 @@ const usePaginator = <TScrollable extends HTMLElement | null = null>({
     scrollableRef
   } = useScrollIntoView<HTMLDivElement, TScrollable>({
     duration: 200,
-    offset: 40
+    offset: scrollOffset
   })
 
   const prevPageRef = useRef(page)

--- a/seta-react/src/hooks/use-pinned.ts
+++ b/seta-react/src/hooks/use-pinned.ts
@@ -1,0 +1,15 @@
+import { useIntersection } from '@mantine/hooks'
+
+/**
+ * Hook based on the IntersectionObserver API to detect if an element is pinned
+ * @returns `pinnedRef` to be passed to the element to be tracked and `isPinned` to check if the element is pinned
+ */
+const usePinned = () => {
+  const { ref: pinnedRef, entry } = useIntersection({ threshold: 1 })
+
+  const isPinned = entry?.isIntersecting === false
+
+  return { pinnedRef, isPinned }
+}
+
+export default usePinned

--- a/seta-react/src/layouts/AdminLayout/components/SidebarContent/styles.ts
+++ b/seta-react/src/layouts/AdminLayout/components/SidebarContent/styles.ts
@@ -25,7 +25,7 @@ export const linkChild: ThemedCSS = theme => css`
   border-left: ${rem(1)} solid
     ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]};
 
-  '&:hover': {
+  &:hover {
     background-color: ${theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.colors.gray[0]};
     color: ${theme.colorScheme === 'dark' ? theme.white : theme.black};
   }

--- a/seta-react/src/pages/SearchPageNew/components/SearchResults/SearchResults.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResults/SearchResults.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from 'react'
+import { Box } from '@mantine/core'
+
+import * as S from './styles'
+
+import SearchResultsTabs from '../SearchResultsTabs'
+
+type Props = {
+  children: ReactElement
+}
+
+const SearchResults = ({ children }: Props) => {
+  return (
+    <Box css={S.root} mt="2rem">
+      <SearchResultsTabs>{children}</SearchResultsTabs>
+    </Box>
+  )
+}
+
+export default SearchResults

--- a/seta-react/src/pages/SearchPageNew/components/SearchResults/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResults/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchResults'

--- a/seta-react/src/pages/SearchPageNew/components/SearchResults/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResults/styles.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  align-self: stretch;
+  position: sticky;
+  top: ${theme.spacing.sm};
+  z-index: 100;
+`

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/SearchResultsTabs.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/SearchResultsTabs.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react'
+import { Transition } from '@mantine/core'
+import { AiOutlineFileSearch } from 'react-icons/ai'
+import { BiNetworkChart } from 'react-icons/bi'
+import { RiCheckDoubleLine } from 'react-icons/ri'
+
+import Tabs, { Tab } from '~/components/Tabs'
+import { useStagedDocuments } from '~/pages/SearchPageNew/contexts/staged-documents-context'
+import { ResultsTab } from '~/pages/SearchPageNew/types/tabs'
+
+import usePinned from '~/hooks/use-pinned'
+
+import StagedDocsInfo from './components/StagedDocsInfo'
+import * as S from './styles'
+
+import StagedDocsPopup from '../documents/StagedDocsPopup'
+
+type Props = {
+  children: ReactElement
+}
+
+const SearchResultsTabs = ({ children }: Props) => {
+  const { pinnedRef, isPinned } = usePinned()
+
+  const { stagedDocuments } = useStagedDocuments()
+
+  const stagedDocsButton = (
+    <div css={S.stagedDocs}>
+      <Transition transition="pop" mounted={!!stagedDocuments.length}>
+        {styles => <StagedDocsInfo style={styles} docs={stagedDocuments} />}
+      </Transition>
+    </div>
+  )
+
+  return (
+    <Tabs
+      css={S.root}
+      defaultValue={ResultsTab.DOCUMENTS}
+      panels={children}
+      tabsRef={pinnedRef}
+      data-pinned={isPinned}
+    >
+      <div css={S.tabsContainer}>
+        <Tab
+          value={ResultsTab.DOCUMENTS}
+          label="Documents"
+          icon={<AiOutlineFileSearch css={S.documentsIcon} />}
+          color="orange"
+        />
+
+        <Tab value={ResultsTab.CONCEPTS} label="Concepts" icon={<BiNetworkChart />} color="grape" />
+
+        <Tab
+          value={ResultsTab.VALIDATION}
+          label="Validation"
+          icon={<RiCheckDoubleLine />}
+          color="teal"
+        />
+
+        <StagedDocsPopup target={stagedDocsButton} />
+      </div>
+    </Tabs>
+  )
+}
+
+export default SearchResultsTabs

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/DocumentsTab.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/DocumentsTab.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { Stack, Text } from '@mantine/core'
+import { BiSearchAlt } from 'react-icons/bi'
+
+import { TabPanel } from '~/components/Tabs'
+import { SuggestionsLoading } from '~/pages/SearchPageNew/components/common'
+import DocumentsList from '~/pages/SearchPageNew/components/documents/DocumentsList'
+import type { SearchState } from '~/pages/SearchPageNew/types/search'
+import { ResultsTab } from '~/pages/SearchPageNew/types/tabs'
+import { STORAGE_KEY } from '~/pages/SearchPageNew/utils/constants'
+
+import type { DocumentsOptions, DocumentsResponse } from '~/api/search/documents'
+import { storage } from '~/utils/storage-utils'
+
+import * as S from './styles'
+
+const searchStorage = storage<string>(STORAGE_KEY.SEARCH)
+const uploadsStorage = storage<unknown[]>(STORAGE_KEY.UPLOADS)
+
+type Props = {
+  query: SearchState
+  searchOptions: DocumentsOptions | undefined
+  onDocumentsChanged?: (docs: DocumentsResponse) => void
+}
+
+const DocumentsTab = ({ query, searchOptions, onDocumentsChanged }: Props) => {
+  // If there is a saved search, prepare the loading state
+  const initialLoading = useMemo(
+    () => !query && (!!searchStorage.read() || !!uploadsStorage.read()?.length),
+    [query]
+  )
+
+  const documentsList = query && (
+    <DocumentsList
+      query={query.value}
+      terms={query.terms}
+      embeddings={query.embeddings}
+      searchOptions={searchOptions}
+      onDocumentsChanged={onDocumentsChanged}
+    />
+  )
+
+  const noDocuments =
+    !query &&
+    (initialLoading ? (
+      // Replicate the loading state without rendering the DocumentsList
+      // if there are documents to load based on the saved search
+      <SuggestionsLoading size="lg" mt="5rem" color="blue" variant="bars" />
+    ) : (
+      <Stack align="center" css={S.noDocuments}>
+        <BiSearchAlt className="icon" />
+
+        <Text mt="md" align="center" fz="lg" color="dimmed" lh={1.6}>
+          Enter a few terms and press <strong>Search</strong> to find documents.
+        </Text>
+      </Stack>
+    ))
+
+  return (
+    <TabPanel value={ResultsTab.DOCUMENTS}>
+      {documentsList}
+      {noDocuments}
+    </TabPanel>
+  )
+}
+
+export default DocumentsTab

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DocumentsTab'

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/styles.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react'
+
+export const noDocuments: ThemedCSS = theme => css`
+  margin-top: ${theme.spacing.xl};
+  padding: 3rem;
+
+  .icon {
+    color: ${theme.colors.gray[4]};
+    font-size: 3rem;
+  }
+`
+
+export const stagedDocs: ThemedCSS = theme => css`
+  position: absolute;
+  z-index: 1;
+  top: ${theme.spacing.lg};
+  right: ${theme.spacing.md};
+`

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/StagedDocsInfo/StagedDocsInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/StagedDocsInfo/StagedDocsInfo.tsx
@@ -1,0 +1,40 @@
+import { Button, Tooltip, clsx } from '@mantine/core'
+import { GiSaveArrow } from 'react-icons/gi'
+
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+import useMinValue from '~/hooks/use-min-value'
+import type { ClassAndStyleProps } from '~/types/children-props'
+import { pluralize } from '~/utils/string-utils'
+
+type Props = {
+  docs: StagedDocument[]
+  onClick?: () => void
+} & ClassAndStyleProps
+
+const StagedDocsInfo = ({ className, style, docs, onClick }: Props) => {
+  const count = useMinValue(docs.length, 1)
+
+  const label = `${count} ${pluralize('document', count)} staged`
+
+  const classes = clsx(className, 'seta-StagedDocsInfo-root')
+
+  return (
+    <div className={classes} style={style}>
+      <Tooltip label={label}>
+        <Button
+          variant="outline"
+          color="blue"
+          size="xs"
+          fz="sm"
+          leftIcon={<GiSaveArrow size={19} />}
+          onClick={onClick}
+        >
+          {count}
+        </Button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export default StagedDocsInfo

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/StagedDocsInfo/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/StagedDocsInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StagedDocsInfo'

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/index.ts
@@ -1,0 +1,3 @@
+export { default } from './SearchResultsTabs'
+
+export { default as DocumentsTab } from './components/DocumentsTab'

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/styles.ts
@@ -1,0 +1,71 @@
+import { css } from '@emotion/react'
+
+import { CONTENT_MAX_WIDTH, pinnable } from '~/styles'
+
+export const root: ThemedCSS = theme => css`
+  .seta-Tabs-tabsList {
+    ${pinnable}
+
+    padding-top: ${theme.spacing.lg};
+    background-color: ${theme.white};
+    transition: box-shadow 0.2s ${theme.transitionTimingFunction},
+      background-color 0.2s ${theme.transitionTimingFunction};
+
+    .seta-Tabs-tab {
+      transition: box-shadow 0.2s ${theme.transitionTimingFunction};
+    }
+  }
+
+  &[data-pinned='true'] {
+    .seta-Tabs-tabsList {
+      box-shadow: ${theme.shadows.sm};
+      background-color: ${theme.fn.rgba(theme.colors.gray[0], 0.95)};
+      border-bottom-color: ${theme.colors.gray[4]};
+      will-change: box-shadow, background-color;
+
+      .seta-Tabs-tab {
+        &::before {
+          content: none;
+        }
+
+        will-change: box-shadow;
+
+        &[data-active] {
+          background-color: ${theme.white};
+          box-shadow: 0 -0.0625rem 0.1875rem rgba(0, 0, 0, 0.04),
+            rgba(0, 0, 0, 0.04) 0 -0.625rem 0.9375rem -0.3125rem,
+            rgba(0, 0, 0, 0.03) 0 -0.4375rem 0.4375rem -0.3125rem;
+        }
+
+        &:not([data-active]) {
+          background-color: transparent;
+        }
+
+        &:hover:not(:active):not([data-active]) {
+          border-color: ${theme.colors.gray[4]};
+          background-color: transparent;
+        }
+      }
+    }
+  }
+`
+
+export const tabsContainer = css`
+  width: ${CONTENT_MAX_WIDTH};
+  position: relative;
+  display: flex;
+  justify-content: center;
+`
+
+export const documentsIcon = css`
+  margin-right: -1px;
+  stroke-width: 10px;
+  transform: scaleX(1.05);
+`
+
+export const stagedDocs = css`
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+`

--- a/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/styles.ts
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react'
 
+import { CONTENT_MAX_WIDTH } from '~/styles'
+
 const POPUP_HEIGHT = '500px'
 
 export const popup: ThemedCSS = theme => css`
@@ -40,6 +42,6 @@ export const closeButton = css`
 `
 
 export const inputWrapper = css`
-  width: 66vw;
+  width: ${CONTENT_MAX_WIDTH};
   padding: 0;
 `

--- a/seta-react/src/pages/SearchPageNew/components/TokensInput/components/TokensInfo/TokensInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/TokensInput/components/TokensInfo/TokensInfo.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { Center, Flex } from '@mantine/core'
 import { IconWand } from '@tabler/icons-react'
 
 import type { Token } from '~/pages/SearchPageNew/types/token'
+
+import useMinValue from '~/hooks/use-min-value'
 
 import * as S from './styles'
 
@@ -12,22 +14,10 @@ type Props = {
 }
 
 const TokensInfo = ({ tokens, enrichQuery }: Props) => {
-  const lastCountRef = useRef(tokens.length)
-
   const count = useMemo(() => tokens.filter(t => !t.operator).length, [tokens])
 
-  // Memoize the displayed count so that we can hide the info before it changes back to 1 or 0
-  const memoCount = useMemo(() => {
-    let result = count
-
-    if (result < 2) {
-      result = lastCountRef.current
-    }
-
-    lastCountRef.current = result
-
-    return result
-  }, [count])
+  // Keep the displayed count above 2 so that we can hide the info before it changes back to 1 or 0
+  const displayedCount = useMinValue(count, 2)
 
   return (
     <>
@@ -36,7 +26,7 @@ const TokensInfo = ({ tokens, enrichQuery }: Props) => {
       </Center>
 
       <Flex align="center" css={S.item} data-visible={count > 1}>
-        <div css={S.tokens}>{memoCount}</div>
+        <div css={S.tokens}>{displayedCount}</div>
         <div>keywords</div>
       </Flex>
     </>

--- a/seta-react/src/pages/SearchPageNew/components/common/SuggestionsError.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/common/SuggestionsError.tsx
@@ -39,7 +39,14 @@ const SuggestionsError = ({
   )
 
   return (
-    <Flex align="center" justify="center" gap="sm" mt={mt} {...styles}>
+    <Flex
+      className="seta-SuggestionsError-root"
+      align="center"
+      justify="center"
+      gap="sm"
+      mt={mt}
+      {...styles}
+    >
       {icon}
 
       <Text fz={size} color="red.6">

--- a/seta-react/src/pages/SearchPageNew/components/common/SuggestionsLoading.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/common/SuggestionsLoading.tsx
@@ -17,7 +17,13 @@ const SuggestionsLoading = ({
   ...styles
 }: Props) => {
   return (
-    <Flex align="center" justify="center" mt={mt} {...styles}>
+    <Flex
+      className="seta-SuggestionsLoading-root"
+      align="center"
+      justify="center"
+      mt={mt}
+      {...styles}
+    >
       <Loader color={color} size={size} variant={variant} />
     </Flex>
   )

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentChunks/DocumentChunks.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentChunks/DocumentChunks.tsx
@@ -19,16 +19,7 @@ type Props = {
 
 const DocumentChunks = forwardRef<HTMLDivElement, Props>(
   (
-    {
-      currentChunkNumber,
-      currentChunkRef,
-      totalChunks,
-      queryTerms,
-      data,
-      isLoading,
-      error,
-      onTryAgain
-    },
+    { currentChunkNumber, currentChunkRef, queryTerms, data, isLoading, error, onTryAgain },
     ref
   ) => {
     const chunksText = useMemo(

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
@@ -1,4 +1,4 @@
-import { Collapse, Stack } from '@mantine/core'
+import { Stack } from '@mantine/core'
 
 import type { ClassNameProp } from '~/types/children-props'
 import type { Taxonomy } from '~/types/search/documents'
@@ -7,7 +7,6 @@ import ChunkPreview from '../ChunkPreview'
 import TaxonomyInfo from '../TaxonomyInfo'
 
 type Props = ClassNameProp & {
-  open: boolean
   documentTitle: string
   documentId: string
   taxonomy: Taxonomy[] | null
@@ -18,7 +17,6 @@ type Props = ClassNameProp & {
 
 const DocumentDetails = ({
   className,
-  open,
   documentId,
   documentTitle,
   taxonomy,
@@ -39,13 +37,11 @@ const DocumentDetails = ({
   }
 
   return (
-    <Collapse className={className} in={open}>
-      <Stack spacing="sm">
-        {hasTaxonomy && <TaxonomyInfo taxonomy={taxonomy} documentTitle={documentTitle} />}
+    <Stack spacing="sm" className={className}>
+      {hasTaxonomy && <TaxonomyInfo taxonomy={taxonomy} documentTitle={documentTitle} />}
 
-        {chunkText && <ChunkPreview text={chunkText} queryTerms={queryTerms} {...chunkMeta} />}
-      </Stack>
-    </Collapse>
+      {chunkText && <ChunkPreview text={chunkText} queryTerms={queryTerms} {...chunkMeta} />}
+    </Stack>
   )
 }
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/styles.ts
@@ -10,32 +10,16 @@ const fill = keyframes({
   }
 })
 
-export const root: ThemedCSS = theme => css`
-  transition: padding-top 200ms ${theme.transitionTimingFunction},
-    padding-bottom 200ms ${theme.transitionTimingFunction};
-
-  &.open {
-    margin: 0 -${theme.spacing.sm};
-    padding: ${theme.spacing.sm};
-    border-radius: ${theme.radius.sm};
-    border: 1px solid ${theme.colors.gray[3]};
-
-    & [data-details='true'] {
-      border-color: transparent !important;
-      transition: none !important;
-    }
-
-    & [data-info] {
-      margin-top: ${theme.spacing.sm};
-    }
-  }
+const contentMarginLeft: ThemedCSS = theme => css`
+  margin-left: calc(${PROGRESS_WIDTH} + ${theme.spacing.lg});
 `
 
 export const header: ThemedCSS = theme => css`
   display: grid;
-  grid-template-columns: ${PROGRESS_WIDTH} 1fr auto;
+  grid-template-columns: ${PROGRESS_WIDTH} 1fr;
   align-items: center;
   gap: ${theme.spacing.lg};
+
   position: relative;
 
   & .seta-Progress-bar {
@@ -46,7 +30,8 @@ export const header: ThemedCSS = theme => css`
     position: absolute;
     opacity: 0;
     visibility: hidden;
-    left: ${theme.spacing.sm};
+    left: calc(${PROGRESS_WIDTH} / 2);
+    transform: translateX(-50%);
     margin-top: 0;
     width: ${PROGRESS_WIDTH};
     text-align: center;
@@ -58,44 +43,12 @@ export const header: ThemedCSS = theme => css`
     &:hover {
       color: ${theme.colors.gray[7]};
     }
-  }
 
-  &[data-open='true'] {
-    & .score {
+    &.visible {
       opacity: 1;
       visibility: visible;
       margin-top: 2.5rem;
     }
-  }
-
-  &[data-details='true'] {
-    cursor: pointer;
-    margin: 0 -${theme.spacing.sm};
-    padding: 0 ${theme.spacing.sm};
-    border-radius: ${theme.radius.sm};
-    border: 1px solid transparent;
-    transition: border-color 200ms ${theme.transitionTimingFunction};
-
-    &:hover {
-      border-color: ${theme.colors.gray[3]};
-    }
-
-    &:active {
-      transform: translateY(1px);
-    }
-  }
-`
-
-export const chevron: ThemedCSS = theme => css`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${theme.colors.gray[7]};
-  transition: transform 200ms ${theme.transitionTimingFunction};
-  animation: fill 300ms ease;
-
-  &.open {
-    transform: rotate(180deg);
   }
 `
 
@@ -104,14 +57,15 @@ export const title: ThemedCSS = theme => css`
   color: ${theme.colors.dark[5]};
 `
 
-const contentMarginLeft: ThemedCSS = theme => css`
-  margin-left: calc(${PROGRESS_WIDTH} + ${theme.spacing.lg});
+export const info: ThemedCSS = theme => css`
+  ${contentMarginLeft(theme)}
+
+  color: ${theme.colors.gray[6]};
+  transition: margin-top 200ms ${theme.transitionTimingFunction};
 `
 
-export const info: ThemedCSS = theme => css`
-  color: ${theme.colors.gray[6]};
-  ${contentMarginLeft(theme)};
-  transition: margin-top 200ms ${theme.transitionTimingFunction};
+export const infoOpen: ThemedCSS = theme => css`
+  margin-top: ${theme.spacing.sm};
 `
 
 export const path: ThemedCSS = theme => css`
@@ -120,11 +74,6 @@ export const path: ThemedCSS = theme => css`
 
 export const details: ThemedCSS = theme => css`
   ${contentMarginLeft(theme)};
-
-  // Set the margin on the inner div to prevent the content from "jumping" when the details are toggled
-  & > div {
-    margin-top: ${theme.spacing.lg};
-  }
 `
 
 export const Container = styled.div`

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
@@ -48,6 +48,7 @@ const DocumentsList = ({ query, terms, embeddings, searchOptions, onDocumentsCha
       singular: 'document'
     },
     resetPageDependencies: [query, searchOptions],
+    scrollOffset: 80,
     onPageChange: setPage
   })
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/styles.ts
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react'
 
+import { CONTENT_MAX_WIDTH } from '~/styles'
+
 export const root = css`
   position: relative;
-  max-width: 60vw;
+  max-width: ${CONTENT_MAX_WIDTH};
   gap: 2.5rem;
-  margin-top: 2.5rem;
+  margin-top: 1rem;
 `

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/DocumentNode.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/DocumentNode.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Collapse, Flex, Group, Tooltip } from '@mantine/core'
+
+import ChevronToggleIcon from '~/components/ChevronToggleIcon'
+
+import type { ClassNameProp } from '~/types/children-props'
+import type { LibraryItem } from '~/types/library/library-item'
+import { LibraryItemType } from '~/types/library/library-item'
+
+import NewFolderAction from './components/NewFolderAction'
+import { ROOT_ICON, FOLDER_ICON_OPEN, FOLDER_ICON, FILE_ICON } from './constants'
+import { useDocumentsTree } from './contexts/documents-tree-context'
+import * as S from './styles'
+
+type Props = {
+  item: LibraryItem
+  isRoot?: boolean
+} & ClassNameProp
+
+const DocumentNode = ({ className, item, isRoot }: Props) => {
+  const [isExpanded, setIsExpanded] = useState(isRoot ?? false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Store the id of the newly created folder to select after a rerender
+  const [willSelectId, setWillSelectId] = useState<string | null>(null)
+
+  const { foldersOnly, selectable, toggleable, selected, onSelect, selectChild, createNewFolder } =
+    useDocumentsTree()
+
+  const selectChildRef = useRef(selectChild)
+
+  const { title, type, path } = item
+
+  const isFolder = type === LibraryItemType.Folder
+
+  const selectedStyle = selected?.id === item.id && S.selected
+  const editingStyle = (isEditing || isLoading) && S.editing
+  const itemStyle = [S.itemContainer, selectedStyle, editingStyle]
+
+  useEffect(() => {
+    if (willSelectId) {
+      selectChildRef.current(item, willSelectId)
+
+      setWillSelectId(null)
+    }
+  }, [willSelectId, item, type])
+
+  const handleTitleClick = () => {
+    if (isFolder) {
+      setIsExpanded(prev => !prev)
+    }
+
+    if (selectable) {
+      if (toggleable) {
+        const isAlreadySelected = selected?.id === item.id
+        const itemValue = isAlreadySelected ? undefined : item
+
+        onSelect?.(itemValue)
+
+        return
+      }
+
+      if (selected?.id !== item.id) {
+        onSelect?.(item)
+      }
+    }
+  }
+
+  const handleNewFolder = async (name: string) => {
+    if (isExpanded && !children.length) {
+      setIsExpanded(false)
+    }
+
+    setIsLoading(true)
+
+    const newId = await createNewFolder?.(item.id === 'root' ? null : item.id, name)
+
+    setIsLoading(false)
+    setIsExpanded(true)
+
+    if (selectable) {
+      setWillSelectId(newId)
+    }
+  }
+
+  const children = useMemo(
+    () =>
+      isFolder
+        ? foldersOnly
+          ? item.children.filter(({ type: t }) => t === LibraryItemType.Folder)
+          : item.children
+        : [],
+    [item, isFolder, foldersOnly]
+  )
+
+  const content = isFolder && (
+    <Collapse in={isExpanded}>
+      {children.map(child => (
+        <DocumentNode key={child.id} item={child} />
+      ))}
+    </Collapse>
+  )
+
+  const toggleIcon = isFolder && (
+    <ChevronToggleIcon start="right" end="down" size="sm" toggled={isExpanded} css={S.toggleIcon} />
+  )
+
+  const icon = isRoot
+    ? ROOT_ICON
+    : isFolder
+    ? isExpanded
+      ? FOLDER_ICON_OPEN
+      : FOLDER_ICON
+    : FILE_ICON
+
+  const actionsGroup = (
+    <Group spacing="xs" ml="sm" data-actions>
+      {isFolder && (
+        <NewFolderAction
+          isLoading={isLoading}
+          onPopoverChange={setIsEditing}
+          onNewFolder={handleNewFolder}
+        />
+      )}
+    </Group>
+  )
+
+  return (
+    <div css={S.node} className={className}>
+      <Tooltip
+        label={path.join(' / ')}
+        openDelay={1000}
+        withinPortal
+        classNames={S.tooltipStyles().classes}
+        disabled
+      >
+        <div css={itemStyle} onClick={handleTitleClick}>
+          {toggleIcon}
+          <div css={S.icon}>{icon}</div>
+
+          <Flex align="center" justify="space-between" css={S.titleContainer}>
+            <div css={S.title}>{title}</div>
+
+            {actionsGroup}
+          </Flex>
+        </div>
+      </Tooltip>
+
+      {content}
+    </div>
+  )
+}
+
+export default DocumentNode

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/DocumentsTree.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/DocumentsTree.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import UnderDevelopment from '~/components/UnderDevelopment'
+import { SuggestionsError, SuggestionsLoading } from '~/pages/SearchPageNew/components/common'
+
+import { useCreateNewFolder } from '~/api/search/library'
+import type { ClassNameProp } from '~/types/children-props'
+import type { DataProps } from '~/types/data-props'
+import { LibraryItemType } from '~/types/library/library-item'
+import type { LibraryItem, LibraryItemRaw } from '~/types/library/library-item'
+import { getLibraryTree, ROOT_LIBRARY_ITEM_NAME } from '~/utils/library-utils'
+
+import type { DocumentsTreeOptions } from './contexts/documents-tree-context'
+import { DocumentsTreeProvider } from './contexts/documents-tree-context'
+import DocumentNode from './DocumentNode'
+import * as S from './styles'
+
+type Props = DataProps<LibraryItemRaw[]> & {
+  onSelectedChange?: (item?: LibraryItem) => void
+} & DocumentsTreeOptions &
+  ClassNameProp
+
+const DocumentsTree = ({
+  data = [],
+  isLoading,
+  error,
+  selectable,
+  autoSelect,
+  onSelectedChange,
+  onTryAgain,
+  className,
+  ...options
+}: Props) => {
+  const [selected, setSelected] = useState<LibraryItem | undefined>()
+
+  const onSelectedChangeRef = useRef(onSelectedChange)
+
+  const { mutateAsync: createNewFolder } = useCreateNewFolder()
+
+  const dataTree = useMemo(() => getLibraryTree(data), [data])
+
+  const rootNode: LibraryItem = useMemo(
+    () => ({
+      id: 'root',
+      type: LibraryItemType.Folder,
+      order: 0,
+      title: ROOT_LIBRARY_ITEM_NAME,
+      path: [ROOT_LIBRARY_ITEM_NAME],
+      children: dataTree
+    }),
+    [dataTree]
+  )
+
+  const canAutoSelect = autoSelect && !selected && !isLoading && !error
+
+  useEffect(() => {
+    if (canAutoSelect) {
+      setSelected(rootNode)
+      onSelectedChangeRef.current?.(rootNode)
+    }
+  }, [canAutoSelect, rootNode])
+
+  if (error) {
+    return (
+      <SuggestionsError
+        size="md"
+        mt={0}
+        subject="the library folders"
+        withIcon
+        onTryAgain={onTryAgain}
+      />
+    )
+  }
+
+  if (isLoading || !data) {
+    return <SuggestionsLoading size="md" mt={0} color="blue" variant="bars" />
+  }
+
+  const handleSelect = (item?: LibraryItem) => {
+    if (!selectable) {
+      return
+    }
+
+    setSelected(item)
+    onSelectedChange?.(item)
+  }
+
+  const handleSelectChild = (parent: LibraryItem, childId: string) => {
+    if (parent.type !== LibraryItemType.Folder) {
+      return
+    }
+
+    const child = parent.children.find(({ id }) => id === childId)
+
+    if (child) {
+      handleSelect(child)
+    }
+  }
+
+  const handleNewFolder = async (parentId: string | null, title: string): Promise<string> => {
+    const { item } = await createNewFolder({ parentId, title })
+
+    return item.id
+  }
+
+  return (
+    <div className={className}>
+      <UnderDevelopment mb="md" />
+
+      <DocumentsTreeProvider
+        {...options}
+        rootNode={rootNode}
+        selectable={selectable}
+        selected={selected}
+        onSelect={handleSelect}
+        selectChild={handleSelectChild}
+        createNewFolder={handleNewFolder}
+      >
+        <DocumentNode item={rootNode} isRoot css={S.rootNode} />
+      </DocumentsTreeProvider>
+    </div>
+  )
+}
+
+export default DocumentsTree

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/NewFolderAction.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/NewFolderAction.tsx
@@ -1,0 +1,97 @@
+import type { MouseEventHandler } from 'react'
+import { useState } from 'react'
+import { Group, TextInput, ActionIcon } from '@mantine/core'
+import { FaPlus, FaCheck } from 'react-icons/fa'
+
+import ActionIconPopover from '~/components/ActionIconPopover'
+
+import * as S from './styles'
+
+type Props = {
+  isLoading?: boolean
+  onPopoverChange?: (open: boolean) => void
+  onNewFolder?: (name: string) => void
+}
+
+const NewFolderAction = ({ isLoading, onPopoverChange, onNewFolder }: Props) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+
+  const isValid = inputValue.trim().length > 0
+
+  const submitNewFolder = () => {
+    if (!isValid) {
+      return
+    }
+
+    const value = inputValue.trim()
+
+    setIsOpen(false)
+
+    // Reset the input value after the popover closes
+    setTimeout(() => {
+      setInputValue('')
+    }, 200)
+
+    onNewFolder?.(value)
+  }
+
+  const handleSaveClick: MouseEventHandler<HTMLButtonElement> = e => {
+    e.stopPropagation()
+    submitNewFolder()
+  }
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = e => {
+    setInputValue(e.currentTarget.value)
+  }
+
+  const handleInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = e => {
+    if (e.key === 'Enter') {
+      submitNewFolder()
+    }
+  }
+
+  return (
+    <ActionIconPopover
+      action={{
+        icon: <FaPlus size={18} />,
+        color: 'teal',
+        loading: isLoading,
+        active: isLoading,
+        tooltip: 'New folder',
+        onClick: () => setIsOpen(true)
+      }}
+      shadow="xs"
+      css={S.popover}
+      opened={isOpen}
+      onChange={setIsOpen}
+      onOpen={() => onPopoverChange?.(true)}
+      onClose={() => onPopoverChange?.(false)}
+    >
+      <Group>
+        <TextInput
+          placeholder="New folder"
+          size="md"
+          color="teal"
+          css={S.input}
+          autoFocus
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleInputKeyDown}
+        />
+
+        <ActionIcon
+          css={S.saveButton}
+          color="teal"
+          variant="light"
+          disabled={!isValid}
+          onClick={handleSaveClick}
+        >
+          <FaCheck size={18} />
+        </ActionIcon>
+      </Group>
+    </ActionIconPopover>
+  )
+}
+
+export default NewFolderAction

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NewFolderAction'

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/components/NewFolderAction/styles.ts
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react'
+
+export const popover = css`
+  padding: 0;
+  border: none;
+  width: 360px;
+`
+
+export const input: ThemedCSS = theme => css`
+  width: 320px;
+
+  .seta-Input-input {
+    padding-right: 48px;
+
+    &:focus {
+      border-color: ${theme.colors.teal[6]};
+    }
+  }
+`
+
+export const saveButton: ThemedCSS = theme => css`
+  position: absolute;
+  right: ${theme.spacing.xs};
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/constants.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/constants.tsx
@@ -1,0 +1,9 @@
+import { CgFileDocument } from 'react-icons/cg'
+import { FaFolder, FaFolderOpen, FaHome } from 'react-icons/fa'
+
+import * as S from './styles'
+
+export const FOLDER_ICON = <FaFolder preserveAspectRatio="none" css={S.folderIcon} />
+export const FOLDER_ICON_OPEN = <FaFolderOpen preserveAspectRatio="none" css={S.folderOpenIcon} />
+export const FILE_ICON = <CgFileDocument css={S.fileIcon} />
+export const ROOT_ICON = <FaHome />

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/contexts/documents-tree-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/contexts/documents-tree-context.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext } from 'react'
+
+import type { ChildrenProp } from '~/types/children-props'
+import type { LibraryItem } from '~/types/library/library-item'
+
+export type DocumentsTreeOptions = {
+  foldersOnly?: boolean
+  selectable?: boolean
+  autoSelect?: boolean
+  toggleable?: boolean
+}
+
+type DocumentsTreeProviderProps = DocumentsTreeOptions & {
+  rootNode?: LibraryItem
+  selected: LibraryItem | undefined
+  onSelect: (value?: LibraryItem) => void
+  selectChild: (parent: LibraryItem, childId: string) => void
+  // Returns the new folder's id
+  createNewFolder: (parentId: string | null, title: string) => Promise<string>
+}
+
+type DocumentsTreeContextProps = DocumentsTreeProviderProps
+
+const DocumentsTreeContext = createContext<DocumentsTreeContextProps | undefined>(undefined)
+
+export const DocumentsTreeProvider = ({
+  children,
+  ...props
+}: DocumentsTreeProviderProps & ChildrenProp) => (
+  <DocumentsTreeContext.Provider value={props}>{children}</DocumentsTreeContext.Provider>
+)
+
+export const useDocumentsTree = () => {
+  const context = useContext(DocumentsTreeContext)
+
+  if (context === undefined) {
+    throw new Error('useDocumentsTree must be used within a DocumentsTreeProvider')
+  }
+
+  return context
+}

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DocumentsTree'

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsTree/styles.ts
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react'
+import { createStyles } from '@mantine/core'
+
+const FOLDER_ICON_HEIGHT = '20px'
+
+export const rootNode = css`
+  margin-left: 0;
+`
+
+export const node: ThemedCSS = theme => css`
+  margin-left: ${theme.spacing.sm};
+  white-space: nowrap;
+`
+
+export const itemContainer: ThemedCSS = theme => css`
+  position: relative;
+  display: grid;
+  grid-template-columns: 14px 20px 1fr;
+  align-items: center;
+  gap: 6px;
+  padding: ${theme.spacing.xs};
+  border-radius: ${theme.radius.sm};
+  border: 1px solid transparent;
+  cursor: pointer;
+
+  [data-actions] {
+    display: none;
+
+    & > .seta-Group-root {
+      padding: 0;
+
+      & > .seta-ActionIcon-root:first-of-type {
+        margin-left: ${theme.spacing.xs};
+      }
+    }
+  }
+
+  &:hover {
+    background-color: ${theme.colors.gray[1]};
+
+    [data-actions] {
+      display: block;
+    }
+  }
+
+  &:active:not(:focus-within) {
+    transform: translateY(1px);
+  }
+`
+
+export const editing: ThemedCSS = theme => css`
+  background-color: ${theme.colors.gray[1]};
+
+  [data-actions] {
+    display: block;
+  }
+`
+
+export const selected: ThemedCSS = theme => css`
+  background-color: ${theme.colors.blue[0]} !important;
+  border: 1px solid ${theme.colors.blue[2]};
+`
+
+export const toggleIcon = css`
+  grid-column: 1;
+`
+
+export const icon: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[6]};
+  font-size: 1.15rem;
+  line-height: 0;
+  grid-column: 2;
+  justify-self: center;
+  margin-right: 2px;
+`
+
+export const fileIcon: ThemedCSS = theme => css`
+  font-size: 1.4rem;
+  color: ${theme.colors.gray[5]};
+`
+
+export const folderIcon = css`
+  height: ${FOLDER_ICON_HEIGHT};
+`
+
+export const folderOpenIcon = css`
+  height: ${FOLDER_ICON_HEIGHT};
+  font-size: 1.3rem;
+  margin-left: 3px;
+`
+
+export const titleContainer = css`
+  overflow: hidden;
+`
+
+export const title = css`
+  flex: 1;
+  line-height: 1.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+// Must define it with `createStyles` to get the styles applied correctly when rendered 'withinPortal'
+export const tooltipStyles = createStyles(() => ({
+  tooltip: {
+    maxWidth: 300,
+    whiteSpace: 'normal'
+  }
+}))
+
+export const editField = css``

--- a/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/SaveDocumentsContent.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/SaveDocumentsContent.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { Alert, Collapse } from '@mantine/core'
+
+import DocumentsTree from '~/pages/SearchPageNew/components/documents/DocumentsTree'
+
+import type { DataProps } from '~/types/data-props'
+import type { LibraryItem, LibraryItemRaw } from '~/types/library/library-item'
+
+import * as S from './styles'
+
+type Props = DataProps<LibraryItemRaw[]> & {
+  saveError?: string
+  onSelectedChange?: (value?: LibraryItem) => void
+}
+
+const SaveDocumentsContent = ({ saveError, onSelectedChange, ...props }: Props) => {
+  const [errorVisible, setErrorVisible] = useState(!!saveError)
+
+  useEffect(() => {
+    if (saveError) {
+      setErrorVisible(true)
+    }
+  }, [saveError])
+
+  const errorAlert = !!saveError && (
+    <Collapse in={errorVisible}>
+      <Alert
+        title="Error saving documents"
+        color="red"
+        variant="outline"
+        withCloseButton
+        mb="sm"
+        onClose={() => setErrorVisible(false)}
+      >
+        {saveError}
+        <br />
+        Please try again.
+      </Alert>
+    </Collapse>
+  )
+
+  return (
+    <div css={S.contentRoot}>
+      {errorAlert}
+
+      <DocumentsTree
+        css={S.tree}
+        foldersOnly
+        selectable
+        autoSelect
+        onSelectedChange={onSelectedChange}
+        {...props}
+      />
+    </div>
+  )
+}
+
+export default SaveDocumentsContent

--- a/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/SaveDocumentsModal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/SaveDocumentsModal.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { Stack, type ModalProps, Text, Group, Button } from '@mantine/core'
+import { IconWallet } from '@tabler/icons-react'
+
+import CancelButton from '~/components/CancelButton'
+import ScrollModal from '~/components/ScrollModal'
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+import { useLibrary } from '~/api/search/library'
+import type { LibraryItem } from '~/types/library/library-item'
+import type { Document } from '~/types/search/documents'
+import { pluralize } from '~/utils/string-utils'
+
+import SaveDocumentsContent from './SaveDocumentsContent'
+
+const pathToString = (path: string[] = []): string => path.join(' / ')
+
+type Props = ModalProps & {
+  documents: Document[] | StagedDocument[]
+  saving?: boolean
+  saveError?: string
+  onSave?: (target: LibraryItem) => void
+}
+
+const SaveDocumentsModal = ({ documents, saving, saveError, onSave, onClose, ...props }: Props) => {
+  const [selectedTarget, setSelectedTarget] = useState<LibraryItem | undefined>()
+
+  const { data, error, isLoading } = useLibrary()
+
+  const handleSelectedChange = (item?: LibraryItem) => {
+    setSelectedTarget(item)
+  }
+
+  const handleSaveClick = () => {
+    if (selectedTarget) {
+      onSave?.(selectedTarget)
+    }
+  }
+
+  const hasOneDocument = documents.length === 1
+
+  const pluralizedSave = `Save ${documents.length} ${pluralize('document', documents.length)}`
+
+  const title = hasOneDocument ? `Save "${documents[0].title}"` : pluralizedSave
+  const saveLabel = hasOneDocument ? 'Save document' : pluralizedSave
+
+  const titleEl = (
+    <Stack spacing={4}>
+      <Text lh={1.3}>{title} to:</Text>
+
+      <Text size="sm" color="gray">
+        {pathToString(selectedTarget?.path) || '...'}
+      </Text>
+    </Stack>
+  )
+
+  const actions = (
+    <Group spacing="sm">
+      <CancelButton onClick={onClose} />
+
+      <Button
+        color="blue"
+        onClick={handleSaveClick}
+        disabled={isLoading || !!error}
+        loading={saving}
+        loaderPosition="center"
+      >
+        {saveLabel}
+      </Button>
+    </Group>
+  )
+
+  const icon = <IconWallet size={26} />
+
+  return (
+    <ScrollModal {...props} icon={icon} title={titleEl} actions={actions} onClose={onClose}>
+      <SaveDocumentsContent
+        data={data?.items}
+        isLoading={isLoading}
+        error={error}
+        saveError={saveError}
+        onSelectedChange={handleSelectedChange}
+      />
+    </ScrollModal>
+  )
+}
+
+export default SaveDocumentsModal

--- a/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SaveDocumentsModal'

--- a/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/SaveDocumentsModal/styles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react'
+
+export const contentRoot = css`
+  min-height: 40vh;
+
+  .seta-SuggestionsError-root,
+  .seta-SuggestionsLoading-root {
+    padding-top: 3rem;
+  }
+`
+
+export const tree: ThemedCSS = theme => css`
+  padding: ${theme.spacing.md};
+  background-color: ${theme.white};
+  border: 1px solid ${theme.colors.gray[3]};
+  border-radius: ${theme.radius.sm};
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/StagedDocsPopup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/StagedDocsPopup.tsx
@@ -1,0 +1,115 @@
+import { type ReactElement } from 'react'
+import { useAutoAnimate } from '@formkit/auto-animate/react'
+import { ScrollArea, Stack } from '@mantine/core'
+
+import PopupOverlay from '~/components/PopupOverlay'
+import { useStagedDocuments } from '~/pages/SearchPageNew/contexts/staged-documents-context'
+import useSaveDocsModal from '~/pages/SearchPageNew/hooks/use-save-docs-modal'
+
+import useScrolled from '~/hooks/use-scrolled'
+import { CONTENT_MAX_WIDTH } from '~/styles'
+
+import StagedActions from './components/StagedActions'
+import StagedDocInfo from './components/StagedDocInfo'
+import useRemoveDocsModal from './hooks/use-remove-docs-modal'
+import useSelectedDocs from './hooks/use-selected-docs'
+import * as S from './styles'
+
+type Props = {
+  target: ReactElement
+  open?: boolean
+  onOpenChange?: (value: boolean) => void
+}
+
+const StagedDocsPopup = ({ target, open, onOpenChange }: Props) => {
+  const { scrolled, setScrolled, handleScrollChange } = useScrolled({ delta: 10 })
+  const { stagedDocuments, removeStaged, clearStaged } = useStagedDocuments()
+
+  const {
+    selectedDocs,
+    clearSelectedDocs,
+    isSelected,
+    toggleSelected,
+    handleSelectAll,
+    handleSelectNone,
+    selectNoneDelayed
+  } = useSelectedDocs(stagedDocuments)
+
+  const { handleRemoveOne, handleRemoveSelected, handleRemoveAll, confirmRemoveModal } =
+    useRemoveDocsModal({
+      selectedDocs,
+      clearSelectedDocs,
+      toggleSelected,
+      removeStaged,
+      clearStaged
+    })
+
+  const { handleSave, saveModal } = useSaveDocsModal({
+    selectedDocs,
+    clearSelectedDocs,
+    removeStaged
+  })
+
+  const [animateRef] = useAutoAnimate<HTMLDivElement>({ duration: 200 })
+
+  const actionsStyle = [S.actions, scrolled && S.withShadow]
+
+  // If the popup is open, but there are no staged documents, close it
+  const internalOpen = !!stagedDocuments.length && open
+
+  const handlePopupClose = () => {
+    selectNoneDelayed()
+    setScrolled(false)
+  }
+
+  const documents = (
+    <ScrollArea css={S.scrollArea} onScrollPositionChange={handleScrollChange}>
+      <div ref={animateRef} css={S.docs}>
+        {stagedDocuments.map(doc => (
+          <StagedDocInfo
+            key={doc.id}
+            document={doc}
+            selected={isSelected(doc)}
+            onSelectChange={selected => toggleSelected(selected, doc)}
+            onRemove={() => handleRemoveOne(doc)}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  )
+
+  return (
+    <>
+      <PopupOverlay
+        target={target}
+        open={internalOpen}
+        width={CONTENT_MAX_WIDTH}
+        position="bottom-end"
+        shadow="lg"
+        offset={-34}
+        onOpenChange={onOpenChange}
+        onClose={handlePopupClose}
+      >
+        <Stack px="xs" spacing={0} mah="100%" className="flex-1">
+          <StagedActions
+            css={actionsStyle}
+            stagedCount={stagedDocuments.length}
+            selectedCount={selectedDocs.length}
+            onSelectAll={handleSelectAll}
+            onSelectNone={handleSelectNone}
+            onRemoveAll={handleRemoveAll}
+            onRemoveSelected={handleRemoveSelected}
+            onSaveSelected={handleSave}
+          />
+
+          {documents}
+        </Stack>
+
+        {confirmRemoveModal}
+        {saveModal}
+      </PopupOverlay>
+    </>
+  )
+}
+
+export default StagedDocsPopup

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/StagedActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/StagedActions.tsx
@@ -1,0 +1,159 @@
+import { ActionIcon, Group, Stack, Text, Tooltip } from '@mantine/core'
+import { IconWallet } from '@tabler/icons-react'
+import { FiCornerUpRight } from 'react-icons/fi'
+import { GiSaveArrow } from 'react-icons/gi'
+import { MdClose } from 'react-icons/md'
+
+import ToggleTransition from '~/components/ToggleTransition'
+
+import type { ClassNameProp } from '~/types/children-props'
+import { pluralize } from '~/utils/string-utils'
+
+import { SELECT_ALL_INFO, SELECT_NONE_INFO } from './constants'
+import * as S from './styles'
+
+type Props = ClassNameProp & {
+  stagedCount: number
+  selectedCount?: number
+  onSelectAll?: () => void
+  onSelectNone?: () => void
+  onExportAll?: () => void
+  onRemoveAll?: () => void
+  onSaveSelected?: () => void
+  onExportSelected?: () => void
+  onRemoveSelected?: () => void
+}
+
+const StagedActions = ({
+  className,
+  stagedCount,
+  selectedCount,
+  onSelectAll,
+  onSelectNone,
+  onRemoveAll,
+  onExportAll,
+  onSaveSelected,
+  onExportSelected,
+  onRemoveSelected
+}: Props) => {
+  const anySelected = !!selectedCount
+
+  const selectAction = anySelected ? SELECT_NONE_INFO : SELECT_ALL_INFO
+
+  const selectAllIcon = SELECT_ALL_INFO.icon
+  const selectNoneIcon = SELECT_NONE_INFO.icon
+
+  const handleSelectAllToggle = () => {
+    if (anySelected) {
+      onSelectNone?.()
+    } else {
+      onSelectAll?.()
+    }
+  }
+
+  const handleRemoveSelected = () => {
+    if (selectedCount === stagedCount) {
+      onRemoveAll?.()
+
+      return
+    }
+
+    onRemoveSelected?.()
+  }
+
+  const docsLabel = pluralize('document', stagedCount)
+
+  const info = selectedCount
+    ? `${selectedCount} of ${stagedCount} ${docsLabel} selected`
+    : `${stagedCount} ${docsLabel} staged`
+
+  const defaultActions = (
+    <Group spacing="xs" css={S.defaultActions}>
+      <Tooltip label="Export all staged documents">
+        <ActionIcon variant="outline" size="lg" radius="xl" color="blue" onClick={onExportAll}>
+          <FiCornerUpRight size="1.2rem" />
+        </ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Clear all staged documents">
+        <ActionIcon variant="outline" size="lg" radius="xl" color="red" onClick={onRemoveAll}>
+          <MdClose size="1.3rem" />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  )
+
+  const selectedActions = (
+    <Group spacing="xs" css={S.selectedActions}>
+      <Tooltip label="Add selected to my documents">
+        <ActionIcon variant="filled" size="lg" radius="xl" color="orange" onClick={onSaveSelected}>
+          <IconWallet size="1.3rem" />
+        </ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Export selected">
+        <ActionIcon variant="filled" size="lg" radius="xl" color="blue" onClick={onExportSelected}>
+          <FiCornerUpRight size="1.2rem" />
+        </ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Remove selected">
+        <ActionIcon
+          variant="filled"
+          size="lg"
+          radius="xl"
+          color="red"
+          onClick={handleRemoveSelected}
+        >
+          <MdClose size="1.3rem" />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  )
+
+  return (
+    <Group className={className} css={S.root} position="apart" align="center">
+      <Tooltip.Group openDelay={300} closeDelay={200}>
+        <Group spacing="xs">
+          <Tooltip label={selectAction.tooltip}>
+            <ActionIcon
+              variant="outline"
+              size="lg"
+              radius="xl"
+              color={selectAction.color}
+              mr="sm"
+              onClick={handleSelectAllToggle}
+            >
+              <ToggleTransition
+                transitionIn="slide-up"
+                transitionOut="slide-down"
+                toggled={anySelected}
+                toggledElement={selectNoneIcon}
+              >
+                {selectAllIcon}
+              </ToggleTransition>
+            </ActionIcon>
+          </Tooltip>
+
+          {anySelected ? selectedActions : defaultActions}
+        </Group>
+      </Tooltip.Group>
+
+      <Stack spacing={3} css={S.info}>
+        <Group spacing="sm">
+          <GiSaveArrow />
+
+          <Text size="sm" weight={500} color="gray.6">
+            {info}
+          </Text>
+        </Group>
+
+        <Text size="sm" color="gray.5">
+          Use the buttons on the left to perform bulk actions
+        </Text>
+      </Stack>
+    </Group>
+  )
+}
+
+export default StagedActions

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/constants.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/constants.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+import type { DefaultMantineColor } from '@mantine/core'
+import { FiCheckSquare, FiSquare } from 'react-icons/fi'
+
+type SelectActionInfo = {
+  tooltip: string
+  icon: ReactNode
+  color: DefaultMantineColor
+}
+
+export const SELECT_ALL_INFO: SelectActionInfo = {
+  tooltip: 'Select all',
+  icon: <FiCheckSquare size="1.3rem" />,
+  color: 'teal'
+}
+
+export const SELECT_NONE_INFO: SelectActionInfo = {
+  tooltip: 'Select none',
+  icon: <FiSquare size="1.3rem" />,
+  color: 'pink'
+}

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StagedActions'

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedActions/styles.ts
@@ -1,0 +1,44 @@
+import { css, keyframes } from '@emotion/react'
+
+const selectedActionsEntry = keyframes({
+  from: {
+    transform: 'translateX(-1rem)',
+    opacity: 0
+  },
+  to: {
+    transform: 'translateX(0)',
+    opacity: 1
+  }
+})
+
+const defaultActionsEntry = keyframes({
+  from: {
+    transform: 'translateX(1rem)',
+    opacity: 0
+  },
+  to: {
+    transform: 'translateX(0)',
+    opacity: 1
+  }
+})
+
+export const root: ThemedCSS = theme => css`
+  height: 4rem;
+  padding-bottom: ${theme.spacing.sm};
+  border-bottom: 1px solid ${theme.colors.gray[3]};
+`
+
+export const info: ThemedCSS = theme => css`
+  svg {
+    font-size: 1.2rem;
+    color: ${theme.colors.gray[5]};
+  }
+`
+
+export const defaultActions: ThemedCSS = theme => css`
+  animation: ${defaultActionsEntry} 200ms ${theme.transitionTimingFunction};
+`
+
+export const selectedActions: ThemedCSS = theme => css`
+  animation: ${selectedActionsEntry} 200ms ${theme.transitionTimingFunction};
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/StagedDocInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/StagedDocInfo.tsx
@@ -1,0 +1,50 @@
+import type { MouseEventHandler } from 'react'
+import { ActionIcon, Checkbox, Group, Text, Tooltip } from '@mantine/core'
+import { CgFileDocument } from 'react-icons/cg'
+import { MdClose } from 'react-icons/md'
+
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+import * as S from './styles'
+
+type Props = {
+  document: StagedDocument
+  selected?: boolean
+  onSelectChange?: (selected: boolean) => void
+  onRemove?: () => void
+}
+
+const StagedDocInfo = ({ document, selected, onSelectChange, onRemove }: Props) => {
+  const { title } = document
+
+  const handleSelect = () => {
+    onSelectChange?.(!selected)
+  }
+
+  const handleRemove: MouseEventHandler<HTMLButtonElement> = event => {
+    event.stopPropagation()
+    onRemove?.()
+  }
+
+  return (
+    <div css={S.root} onClick={handleSelect}>
+      <Checkbox css={S.checkbox} color="teal" checked={selected} onChange={handleSelect} />
+
+      <Group spacing="xs">
+        <CgFileDocument css={S.icon} />
+
+        <Text size="lg" style={{ flex: 1 }} truncate>
+          {title}
+        </Text>
+      </Group>
+
+      <Tooltip label="Remove from staged documents">
+        <ActionIcon variant="subtle" color="gray" data-action="remove" onClick={handleRemove}>
+          <MdClose />
+        </ActionIcon>
+      </Tooltip>
+    </div>
+  )
+}
+
+export default StagedDocInfo

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StagedDocInfo'

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/components/StagedDocInfo/styles.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react'
+
+import { outlineTransition } from '~/styles'
+
+const GAP = '2rem'
+
+export const root: ThemedCSS = theme => css`
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: ${GAP};
+  align-items: center;
+  padding: ${theme.spacing.xs} ${theme.spacing.sm};
+  border-radius: ${theme.radius.sm};
+  transition: ${outlineTransition}, margin 0.2s ${theme.transitionTimingFunction};
+  cursor: pointer;
+
+  [data-action='remove'] {
+    visibility: hidden;
+    font-size: 1.2em;
+
+    &:hover {
+      background-color: ${theme.colors.red[5]};
+      color: ${theme.colors.red[0]};
+    }
+  }
+
+  &:hover,
+  &:focus:focus-visible {
+    background-color: ${theme.colors.gray[1]};
+
+    [data-action='remove'] {
+      visibility: visible;
+    }
+  }
+
+  &:active:not(:focus-within) {
+    transform: translateY(1px);
+  }
+`
+
+export const checkbox = css`
+  .seta-Checkbox-input {
+    cursor: pointer;
+  }
+`
+
+export const icon: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[5]};
+  font-size: 1.5rem;
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/hooks/use-remove-docs-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/hooks/use-remove-docs-modal.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import { css } from '@emotion/react'
+import { CgRemoveR } from 'react-icons/cg'
+
+import ConfirmModal from '~/components/ConfirmModal'
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+type RemoveModalState =
+  | {
+      open: false
+    }
+  | {
+      open: true
+      type: 'document'
+      doc: StagedDocument
+    }
+  | {
+      open: true
+      type: 'selected'
+      docs: StagedDocument[]
+    }
+  | {
+      open: true
+      type: 'all'
+    }
+
+let lastRemoveInfo: [string, string, string] = ['', '', '']
+
+const getRemoveInfo = (state: RemoveModalState): [string, string, string] => {
+  if (!state.open) {
+    // If the modal is closed, return the last info so that
+    // the text doesn't change until the closing animation is finished
+    return lastRemoveInfo
+  }
+
+  switch (state.type) {
+    case 'document':
+      lastRemoveInfo = ['document', 'this document from the list', 'it']
+      break
+
+    case 'selected':
+      lastRemoveInfo = [
+        `${state.docs.length} documents`,
+        `${state.docs.length} documents from the list`,
+        'them'
+      ]
+
+      break
+
+    case 'all':
+      lastRemoveInfo = ['all staged', 'all the staged documents', 'them']
+      break
+  }
+
+  return lastRemoveInfo
+}
+
+const removeIconStyle: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[6]};
+  font-size: 3.2rem;
+`
+
+type Args = {
+  selectedDocs: StagedDocument[]
+  clearSelectedDocs: () => void
+  toggleSelected: (selected: boolean, doc: StagedDocument) => void
+  removeStaged: (ids: string | string[]) => void
+  clearStaged: () => void
+}
+
+const useRemoveDocsModal = ({
+  selectedDocs,
+  clearSelectedDocs,
+  toggleSelected: toggleSelectedDoc,
+  removeStaged,
+  clearStaged
+}: Args) => {
+  const [removeModal, setRemoveModal] = useState<RemoveModalState>({ open: false })
+
+  const handleRemoveAll = () => {
+    setRemoveModal({ open: true, type: 'all' })
+  }
+
+  const handleRemoveSelected = () => {
+    if (selectedDocs.length === 1) {
+      setRemoveModal({ open: true, type: 'document', doc: selectedDocs[0] })
+    } else {
+      setRemoveModal({ open: true, type: 'selected', docs: selectedDocs })
+    }
+  }
+
+  const handleRemoveOne = (doc: StagedDocument) => {
+    setRemoveModal({ open: true, type: 'document', doc })
+  }
+
+  const closeRemoveModal = () => {
+    setRemoveModal({ open: false })
+  }
+
+  const handleRemoveStaged = () => {
+    if (!removeModal.open) {
+      return
+    }
+
+    switch (removeModal.type) {
+      case 'document':
+        const doc = removeModal.doc
+
+        toggleSelectedDoc(false, doc)
+        removeStaged(doc.id)
+        break
+
+      case 'selected':
+        const docs = removeModal.docs
+
+        removeStaged(docs.map(d => d.id))
+        clearSelectedDocs()
+        break
+
+      case 'all':
+        clearStaged()
+        break
+    }
+
+    closeRemoveModal()
+  }
+
+  const [removeName, removeText, removeSecondary] = getRemoveInfo(removeModal)
+  const removeModalText = `Are you sure you want to remove ${removeText}?`
+
+  const confirmRemoveModal = (
+    <ConfirmModal
+      icon={<CgRemoveR css={removeIconStyle} />}
+      text={removeModalText}
+      secondary={`You can add ${removeSecondary} back later from the search results.`}
+      confirmLabel={`Remove ${removeName}`}
+      confirmColor="red"
+      withinPortal={false}
+      zIndex={1000}
+      opened={removeModal.open}
+      onClose={closeRemoveModal}
+      onConfirm={handleRemoveStaged}
+    />
+  )
+
+  return {
+    handleRemoveAll,
+    handleRemoveSelected,
+    handleRemoveOne,
+    confirmRemoveModal
+  }
+}
+
+export default useRemoveDocsModal

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/hooks/use-selected-docs.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/hooks/use-selected-docs.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from 'react'
+
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+import { toggleArrayValue } from '~/utils/array-utils'
+
+const useSelectedDocs = (stagedDocuments: StagedDocument[]) => {
+  const [selectedDocs, setSelectedDocs] = useState<StagedDocument[]>([])
+
+  const isSelected = useCallback(
+    (doc: StagedDocument) => selectedDocs.some(({ id }) => id === doc.id),
+    [selectedDocs]
+  )
+
+  const toggleSelected = (selected: boolean, doc: StagedDocument) => {
+    setSelectedDocs(toggleArrayValue(selectedDocs, doc, selected, 'id'))
+  }
+
+  const handleSelectAll = () => {
+    setSelectedDocs([...stagedDocuments])
+  }
+
+  const handleSelectNone = () => {
+    setSelectedDocs([])
+  }
+
+  const selectNoneDelayed = () => {
+    // Delay the select none action to allow the popup's closing animation to finish
+    setTimeout(handleSelectNone, 200)
+  }
+
+  const clearSelectedDocs = () => {
+    setSelectedDocs([])
+  }
+
+  return {
+    selectedDocs,
+    setSelectedDocs,
+    clearSelectedDocs,
+    isSelected,
+    toggleSelected,
+    handleSelectAll,
+    handleSelectNone,
+    selectNoneDelayed
+  }
+}
+
+export default useSelectedDocs

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StagedDocsPopup'

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/styles.ts
@@ -1,0 +1,30 @@
+import { css } from '@emotion/react'
+
+export const actions: ThemedCSS = theme => css`
+  padding-left: calc(${theme.spacing.xs} / 2);
+  transition: box-shadow 0.2s ${theme.transitionTimingFunction},
+    margin 0.2s ${theme.transitionTimingFunction}, padding 0.2s ${theme.transitionTimingFunction};
+`
+
+const marginPadding: ThemedCSS = theme => css`
+  margin-left: -${theme.spacing.xl};
+  margin-right: -${theme.spacing.xl};
+  padding-left: ${theme.spacing.xl};
+  padding-right: ${theme.spacing.xl};
+`
+
+export const withShadow: ThemedCSS = theme => css`
+  box-shadow: ${theme.shadows.sm};
+  z-index: 1;
+
+  ${marginPadding(theme)}
+  padding-left: calc(${theme.spacing.xs} / 2 + ${theme.spacing.xl});
+`
+
+export const docs: ThemedCSS = theme => css`
+  padding-top: ${theme.spacing.md};
+`
+
+export const scrollArea: ThemedCSS = theme => css`
+  ${marginPadding(theme)}
+`

--- a/seta-react/src/pages/SearchPageNew/components/upload/TextUpload/TextUpload.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/upload/TextUpload/TextUpload.tsx
@@ -4,6 +4,7 @@ import { Button, Group, Stack, Text, Textarea } from '@mantine/core'
 import { GrTextAlignLeft } from 'react-icons/gr'
 import { HiUpload } from 'react-icons/hi'
 
+import CancelButton from '~/components/CancelButton'
 import { useUploadDocuments } from '~/pages/SearchPageNew/contexts/upload-documents-context'
 
 import useSpacebarAction from '~/hooks/use-spacebar-action'
@@ -75,6 +76,8 @@ const TextUpload = ({ className, editing, onEdit, onCancel }: Props) => {
         />
 
         <Group spacing="sm" css={S.actions} data-loading={isLoading}>
+          <CancelButton onClick={onCancel} data-cancel />
+
           <Button
             color="teal"
             variant="filled"
@@ -83,10 +86,6 @@ const TextUpload = ({ className, editing, onEdit, onCancel }: Props) => {
             onClick={handleUpload}
           >
             {isLoading ? 'Uploading...' : 'Upload Text'}
-          </Button>
-
-          <Button color="gray.7" variant="light" onClick={onCancel} data-cancel>
-            Cancel
           </Button>
         </Group>
       </Stack>

--- a/seta-react/src/pages/SearchPageNew/components/upload/UploadedDocs/UploadedDocs.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/upload/UploadedDocs/UploadedDocs.tsx
@@ -32,13 +32,13 @@ type RemoveModalState = {
 const getRemoveValues = (type: RemoveType | undefined, id?: string) => {
   switch (type) {
     case 'chunk':
-      return ['Chunk', `the chunk ${id}`]
+      return ['chunk', `the chunk ${id}`]
 
     case 'document':
-      return ['Document', `the document ${id}`]
+      return ['document', `the document ${id}`]
 
     case 'all':
-      return ['All Entries', 'all the entries']
+      return ['all entries', 'all the entries']
 
     default:
       return ['', '']

--- a/seta-react/src/pages/SearchPageNew/contexts/staged-documents-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/contexts/staged-documents-context.tsx
@@ -1,0 +1,102 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+import { STORAGE_KEY } from '~/pages/SearchPageNew/utils/constants'
+
+import type { ChildrenProp } from '~/types/children-props'
+import { toggleArrayValue } from '~/utils/array-utils'
+import { storage } from '~/utils/storage-utils'
+
+type StagedDocumentsContextProps = {
+  isStaged: (documentId: string) => boolean
+  toggleStaged: (documentId: string, documentTitle: string, staged: boolean) => void
+  removeStaged: (documentId: string | string[]) => void
+  clearStaged: () => void
+  stagedDocuments: StagedDocument[]
+}
+
+const WRITE_STORAGE_DELAY = 50
+
+const stagedDocsStorage = storage<StagedDocument[]>(STORAGE_KEY.STAGED_DOCS)
+
+const StagedDocumentsContext = createContext<StagedDocumentsContextProps | undefined>(undefined)
+
+/**
+ * Keep track of staged documents in local storage.
+ */
+export const StagedDocumentsProvider = ({ children }: ChildrenProp) => {
+  const [stagedDocuments, setStagedDocuments] = useState<StagedDocument[]>([])
+
+  useEffect(() => {
+    const stagedDocs = stagedDocsStorage.read()
+
+    if (stagedDocs) {
+      setStagedDocuments(stagedDocs)
+    }
+  }, [])
+
+  const isStaged: StagedDocumentsContextProps['isStaged'] = useCallback(
+    documentId => stagedDocuments.some(({ id }) => id === documentId),
+    [stagedDocuments]
+  )
+
+  const toggleStaged: StagedDocumentsContextProps['toggleStaged'] = useCallback(
+    (documentId, documentTitle, staged) => {
+      const doc: StagedDocument = {
+        id: documentId,
+        title: documentTitle
+      }
+
+      const newStagedDocs = toggleArrayValue(stagedDocuments, doc, staged, 'id')
+
+      setStagedDocuments(newStagedDocs)
+
+      setTimeout(() => {
+        stagedDocsStorage.write(newStagedDocs)
+      }, WRITE_STORAGE_DELAY)
+    },
+    [stagedDocuments]
+  )
+
+  const removeStaged: StagedDocumentsContextProps['removeStaged'] = useCallback(
+    documentId => {
+      const ids = Array.isArray(documentId) ? documentId : [documentId]
+      const newStagedDocs = stagedDocuments.filter(({ id }) => !ids.includes(id))
+
+      setStagedDocuments(newStagedDocs)
+
+      setTimeout(() => {
+        stagedDocsStorage.write(newStagedDocs)
+      }, WRITE_STORAGE_DELAY)
+    },
+    [stagedDocuments]
+  )
+
+  const clearStaged: StagedDocumentsContextProps['clearStaged'] = () => {
+    setStagedDocuments([])
+    stagedDocsStorage.write([])
+  }
+
+  const value: StagedDocumentsContextProps = {
+    isStaged,
+    toggleStaged,
+    removeStaged,
+    clearStaged,
+    stagedDocuments
+  }
+
+  return <StagedDocumentsContext.Provider value={value}>{children}</StagedDocumentsContext.Provider>
+}
+
+/**
+ * Hook to access the staged documents context
+ */
+export const useStagedDocuments = () => {
+  const context = useContext(StagedDocumentsContext)
+
+  if (!context) {
+    throw new Error('useStagedDocuments must be used within a StagedDocumentsProvider')
+  }
+
+  return context
+}

--- a/seta-react/src/pages/SearchPageNew/hooks/use-save-docs-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/hooks/use-save-docs-modal.tsx
@@ -1,0 +1,83 @@
+import { useRef, useState } from 'react'
+
+import SaveDocumentsModal from '~/pages/SearchPageNew/components/documents/SaveDocumentsModal'
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
+
+import { useSaveDocuments } from '~/api/search/library'
+import type { LibraryItem } from '~/types/library/library-item'
+
+type Args = {
+  selectedDocs: StagedDocument[]
+  clearSelectedDocs?: () => void
+  removeStaged?: (ids: string | string[]) => void
+}
+
+const useSaveDocsModal = ({ selectedDocs, clearSelectedDocs, removeStaged }: Args) => {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [hasError, setHasError] = useState(false)
+
+  // Use internal state to allow it to be set by the `handleSave` callback
+  const [internalDocs, setInternalDocs] = useState<StagedDocument[]>()
+
+  const lastTargetRef = useRef<LibraryItem | undefined>()
+
+  const { mutate, isLoading } = useSaveDocuments()
+
+  const handleSave = (docs?: StagedDocument[]) => {
+    // Prevent default event argument from being passed using Array.isArray check
+    if (docs && Array.isArray(docs)) {
+      setInternalDocs(docs)
+    }
+
+    setModalOpen(true)
+  }
+
+  // Use internal docs if set, otherwise use selected docs from prop
+  const docs = internalDocs ?? selectedDocs
+
+  const handleSaveDocuments = (target: LibraryItem) => {
+    lastTargetRef.current = target
+    setHasError(false)
+
+    mutate(
+      {
+        parentId: target.id === 'root' ? null : target.id,
+        documents: docs.map(({ id, title }) => ({ documentId: id, title }))
+      },
+      {
+        onSuccess: () => {
+          setModalOpen(false)
+
+          removeStaged?.(docs.map(({ id }) => id))
+          clearSelectedDocs?.()
+        },
+        onError: () => {
+          setHasError(true)
+        }
+      }
+    )
+  }
+
+  const saveError = hasError
+    ? `There was an error saving to '${lastTargetRef.current?.path.join(' / ')}'.`
+    : undefined
+
+  const saveModal = (
+    <SaveDocumentsModal
+      documents={docs}
+      withinPortal={false}
+      opened={modalOpen}
+      saving={isLoading}
+      saveError={saveError}
+      onClose={() => setModalOpen(false)}
+      onSave={handleSaveDocuments}
+    />
+  )
+
+  return {
+    handleSave,
+    saveModal
+  }
+}
+
+export default useSaveDocsModal

--- a/seta-react/src/pages/SearchPageNew/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/styles.ts
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react'
 
-export const searchWrapper = css`
+export const searchWrapper: ThemedCSS = theme => css`
   flex: 1;
+  align-self: stretch;
+  margin-top: ${theme.spacing.xs};
 `
 
 export const noDocuments: ThemedCSS = theme => css`

--- a/seta-react/src/pages/SearchPageNew/types/search.ts
+++ b/seta-react/src/pages/SearchPageNew/types/search.ts
@@ -18,3 +18,14 @@ export type SearchValue = {
   enrichedStatus: EnrichedStatus
   embeddings?: EmbeddingInfo[]
 }
+
+export type SearchState = {
+  value: string
+  terms: string[]
+  embeddings?: EmbeddingInfo[]
+} | null
+
+export type StagedDocument = {
+  id: string
+  title: string
+}

--- a/seta-react/src/pages/SearchPageNew/types/tabs.ts
+++ b/seta-react/src/pages/SearchPageNew/types/tabs.ts
@@ -1,0 +1,5 @@
+export enum ResultsTab {
+  DOCUMENTS = 'documents',
+  CONCEPTS = 'concepts',
+  VALIDATION = 'validation'
+}

--- a/seta-react/src/pages/SearchPageNew/utils/constants.ts
+++ b/seta-react/src/pages/SearchPageNew/utils/constants.ts
@@ -1,5 +1,6 @@
 export const STORAGE_KEY = {
   SEARCH: 'seta-search-value',
   ENRICH: 'seta-search-enrich',
-  UPLOADS: 'seta-search-uploads'
+  UPLOADS: 'seta-search-uploads',
+  STAGED_DOCS: 'seta-search-staged-docs'
 }

--- a/seta-react/src/pages/SearchWithFilters/components/SidePanel/SidePanel.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/SidePanel/SidePanel.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react'
 import type { DefaultMantineColor } from '@mantine/core'
-import { Alert, Box } from '@mantine/core'
-import { IconAlertCircle, IconListSearch, IconSearch, IconWallet } from '@tabler/icons-react'
+import { Box } from '@mantine/core'
+import { IconListSearch, IconSearch, IconWallet } from '@tabler/icons-react'
 
 import ToggleSection from '~/components/ToggleSection'
+import UnderDevelopment from '~/components/UnderDevelopment/UnderDevelopment'
+import DocumentsTree from '~/pages/SearchPageNew/components/documents/DocumentsTree'
 import { FilterStatus } from '~/pages/SearchWithFilters/types/filter-info'
+
+import { useLibrary } from '~/api/search/library'
 
 import type { AdvancedFilterProps } from '../../types/contracts'
 import FiltersPanel from '../FiltersPanel'
@@ -23,6 +27,8 @@ const SidePanel = ({
   filtersDisabled
 }: AdvancedFilterProps) => {
   const [filtersStatus, setFiltersStatus] = useState<FilterStatus | null>(null)
+
+  const { data: libraryData, isLoading, error, refetch } = useLibrary()
 
   const marker = markerColor[filtersStatus ?? FilterStatus.UNKNOWN]
 
@@ -44,15 +50,16 @@ const SidePanel = ({
       </ToggleSection>
 
       <ToggleSection icon={<IconSearch size={20} />} color="grape" title="My Search">
-        <Alert icon={<IconAlertCircle size="1rem" />} title="Not implemented yet!" color="red">
-          This panel will contain my search library.
-        </Alert>
+        <UnderDevelopment variant="coming-soon" />
       </ToggleSection>
 
       <ToggleSection icon={<IconWallet size={20} />} color="orange" title="My Documents">
-        <Alert icon={<IconAlertCircle size="1rem" />} title="Not implemented yet!" color="red">
-          This panel will contain my documents library.
-        </Alert>
+        <DocumentsTree
+          data={libraryData?.items}
+          isLoading={isLoading}
+          error={error}
+          onTryAgain={refetch}
+        />
       </ToggleSection>
     </Box>
   )

--- a/seta-react/src/styles/global-styles.ts
+++ b/seta-react/src/styles/global-styles.ts
@@ -32,7 +32,13 @@ const globalStyles: MantineThemeOverride['globalStyles'] = theme => ({
   'button:-moz-focusring, [type="button"]:-moz-focusring, [type="reset"]:-moz-focusring, [type="submit"]:-moz-focusring':
     {
       outline: `0.125rem solid ${theme.colors[theme.primaryColor][5]}`
-    }
+    },
+
+  '.pinnable': {
+    position: 'sticky',
+    top: -1,
+    zIndex: 10
+  }
 })
 
 export default globalStyles

--- a/seta-react/src/styles/global.ts
+++ b/seta-react/src/styles/global.ts
@@ -5,6 +5,8 @@ import type { CSSObject, MantineTheme } from '@mantine/core'
 
 export const PAGE_PADDING = '2rem'
 
+export const CONTENT_MAX_WIDTH = '66vw'
+
 export const outlineTransition = 'outline-color 100ms ease, outline-offset 100ms ease'
 
 export const unfocusedOutlineStyles = css`
@@ -58,3 +60,9 @@ export const focusedOutlineStylesObject = (theme: MantineTheme): CSSObject => ({
   outlineOffset: '0.125rem',
   outline: `0.125rem solid ${theme.colors[theme.primaryColor][5]}`
 })
+
+export const pinnable = css`
+  position: sticky;
+  top: -1px;
+  z-index: 10;
+`

--- a/seta-react/src/types/children-props.ts
+++ b/seta-react/src/types/children-props.ts
@@ -1,7 +1,7 @@
-import type { UserRole } from './user'
+import type { CSSProperties, ReactNode } from 'react'
 
 export type ChildrenProp = {
-  children: React.ReactElement
+  children: ReactNode
 }
 
 export type PropsWithChildren<P> = P & ChildrenProp
@@ -12,4 +12,6 @@ export type ClassNameProp = {
 
 export type ClassAndChildrenProps = ClassNameProp & ChildrenProp
 
-export type AllowedRolesAndChildrenProps = { allowedRoles?: UserRole[] } & ChildrenProp
+export type ClassAndStyleProps = ClassNameProp & {
+  style?: CSSProperties
+}

--- a/seta-react/src/types/data-props.ts
+++ b/seta-react/src/types/data-props.ts
@@ -1,6 +1,6 @@
 export type DataProps<T> = {
   data: T | undefined
-  isLoading: boolean
-  error: unknown
+  isLoading?: boolean
+  error?: unknown
   onTryAgain?: () => void
 }

--- a/seta-react/src/types/lib-props.ts
+++ b/seta-react/src/types/lib-props.ts
@@ -1,4 +1,9 @@
+import type { ActionIconProps } from '@mantine/core'
+
 export type ModalStateProps = {
   opened: boolean
   onClose: () => void
 }
+
+export type Variant = ActionIconProps['variant']
+export type Color = ActionIconProps['color']

--- a/seta-react/src/types/library/library-item.ts
+++ b/seta-react/src/types/library/library-item.ts
@@ -1,0 +1,33 @@
+export enum LibraryItemType {
+  Document = 'document',
+  Folder = 'folder'
+}
+
+export type LibraryItemBase = {
+  id: string
+  title: string
+}
+
+export type LibraryItemRaw = LibraryItemBase & {
+  order: number
+  parentId: string | null
+  type: string
+  documentId?: string
+  link?: string | null
+}
+
+export type LibraryItem = LibraryItemBase & {
+  order: number
+  parent?: LibraryItem | null
+  path: string[]
+} & (
+    | {
+        type: LibraryItemType.Document
+        documentId: string
+        link: string | null
+      }
+    | {
+        type: LibraryItemType.Folder
+        children: LibraryItem[]
+      }
+  )

--- a/seta-react/src/utils/array-utils.ts
+++ b/seta-react/src/utils/array-utils.ts
@@ -1,0 +1,31 @@
+const isObject = (value: unknown) => value && typeof value === 'object'
+
+const getIdValue = <T>(value: T, idProp: keyof T | undefined) => {
+  if (isObject(value) && idProp) {
+    return value[idProp]
+  }
+
+  return value
+}
+
+/**
+ * Toggles a value in an array.
+ * @param array The array to toggle the value in.
+ * @param value The value to toggle.
+ * @param toggledOn Whether to toggle the value on or off.
+ * @param idProp The property to use as the ID when comparing objects.
+ * @returns A new instance of the array with the value toggled on or off.
+ */
+export const toggleArrayValue = <T>(array: T[], value: T, toggledOn: boolean, idProp?: keyof T) => {
+  const idOrValue = getIdValue(value, idProp)
+
+  if (toggledOn) {
+    if (array.some(item => getIdValue(item, idProp) === idOrValue)) {
+      return array
+    }
+
+    return [...array, value]
+  }
+
+  return array.filter(item => getIdValue(item, idProp) !== idOrValue)
+}

--- a/seta-react/src/utils/library-utils.ts
+++ b/seta-react/src/utils/library-utils.ts
@@ -1,0 +1,65 @@
+import { LibraryItemType } from '~/types/library/library-item'
+import type { LibraryItem, LibraryItemRaw } from '~/types/library/library-item'
+
+export const ROOT_LIBRARY_ITEM_NAME = 'My Library'
+
+const itemFromRaw = (item: LibraryItemRaw): LibraryItem => {
+  const base = {
+    ...item,
+    path: [ROOT_LIBRARY_ITEM_NAME, item.title]
+  }
+
+  if (item.type === LibraryItemType.Folder) {
+    return {
+      ...base,
+      type: LibraryItemType.Folder,
+      children: []
+    }
+  }
+
+  if (item.type === LibraryItemType.Document) {
+    return {
+      ...base,
+      type: LibraryItemType.Document,
+      documentId: item.documentId ?? '',
+      link: item.link ?? ''
+    }
+  }
+
+  throw new Error('Unknown library item type')
+}
+
+/**
+ * Converts a flat array of `LibraryItemRaw` elements into a tree structure made of `LibraryItem` values
+ * @param items The flat array to convert
+ * @returns The tree structure with multiple roots
+ */
+export const getLibraryTree = (items: LibraryItemRaw[]): LibraryItem[] => {
+  const map = new Map<string, LibraryItem>()
+  const roots: LibraryItem[] = []
+
+  for (const item of items) {
+    map.set(item.id, itemFromRaw(item))
+  }
+
+  for (const item of items) {
+    // The map.get() call is safe because we've just set the value
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const mappedItem = map.get(item.id)!
+
+    if (item.parentId) {
+      const parent = map.get(item.parentId)
+
+      if (parent && parent.type === LibraryItemType.Folder) {
+        parent.children.push(mappedItem)
+
+        mappedItem.parent = parent
+        mappedItem.path = [...parent.path, mappedItem.title]
+      }
+    } else {
+      roots.push(mappedItem)
+    }
+  }
+
+  return roots
+}

--- a/seta-react/src/utils/string-utils.ts
+++ b/seta-react/src/utils/string-utils.ts
@@ -1,2 +1,21 @@
+/**
+ * Trims text to a certain length and adds ellipsis if needed
+ * @param text The text to trim
+ * @param width The maximum length of the text (default: 200)
+ * @returns The trimmed text
+ */
 export const trimText = (text: string, width = 200): string =>
   text.length > width ? `${text.slice(0, width)}...` : text
+
+/**
+ * Pluralizes a word based on a count
+ * @param word The word to pluralize
+ * @param count The count to check
+ * @param plural The optional plural form of the word (defaults to adding an 's' at the end)
+ * @returns The pluralized word
+ */
+export const pluralize = (word: string, count: number, plural?: string): string => {
+  const pluralWord = plural ?? `${word}s`
+
+  return count === 1 ? word : pluralWord
+}

--- a/seta-react/src/utils/styled-utils.ts
+++ b/seta-react/src/utils/styled-utils.ts
@@ -1,0 +1,15 @@
+import type { CreateStyled } from '@emotion/styled'
+
+/**
+ * This is a helper configuration to create a styled component with transient props.
+ *
+ * Any prop that starts with `$` will not be passed to the DOM element.
+ *
+ * Pass this as the second argument to `styled` from `@emotion/styled`.
+ *
+ * @example
+ * const MyStyledComponent = styled(MyComponent, transientProps)
+ */
+export const transientProps: Parameters<CreateStyled>[1] = {
+  shouldForwardProp: prop => prop !== 'theme' && !prop.startsWith('$')
+}


### PR DESCRIPTION
This PR add the initial implementation of `My Documents`, together with the possibility to create new folder and save documents from the search results to a specific folder.

The folders structure is currently only saved in memory, so it will reset to the provided defaults when reloading the page.

Also introduces the Staged Documents dropdown, plus a number of utilities and helpers to optimize development.