### PR TITLE
[seta-react] Improve suggestions popup closing

### DIFF
--- a/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/SuggestionsPopup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SuggestionsPopup/SuggestionsPopup.tsx
@@ -167,7 +167,6 @@ const SuggestionsPopup = ({ opened, enrichQuery, onOpenChange, onEnrichToggle }:
       arrowSize={16}
       shadow="sm"
       offset={10}
-      closeOnClickOutside={false}
     >
       <Popover.Target>
         <SearchInput

--- a/seta-react/src/pages/SearchPageNew/components/upload/ChunkDetailsModal/ChunkDetailsModal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/upload/ChunkDetailsModal/ChunkDetailsModal.tsx
@@ -26,7 +26,14 @@ const ChunkDetailsModal = ({ chunk, ...props }: Props) => {
   )
 
   return (
-    <ScrollModal title={title} icon={<ImEmbed />} zIndex={300} fullScreenToggle {...props}>
+    <ScrollModal
+      title={title}
+      icon={<ImEmbed />}
+      fullScreenToggle
+      withinPortal={false}
+      zIndex={300}
+      {...props}
+    >
       <div css={S.textView}>{text}</div>
     </ScrollModal>
   )

--- a/seta-react/src/pages/SearchPageNew/components/upload/UploadedDocs/UploadedDocs.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/upload/UploadedDocs/UploadedDocs.tsx
@@ -135,6 +135,7 @@ const UploadedDocs = ({ className, onAddText }: Props) => {
         confirmLabel={`Remove ${removeName}`}
         confirmColor="red"
         opened={removeModalOpen}
+        withinPortal={false}
         onClose={closeRemoveModal}
         onConfirm={handleRemove}
       />


### PR DESCRIPTION
This PR adds the functionality of closing the Search suggestions popup by clicking outside it, while still keeping it open when clicking on the chunk preview and confirmation modals displayed for uploaded docs/text.