### PR TITLE
Fix search results short document name alignment

### DIFF
--- a/seta-react/src/components/Tabs/components/TabPanel/styles.ts
+++ b/seta-react/src/components/Tabs/components/TabPanel/styles.ts
@@ -15,6 +15,5 @@ export const content = css`
   margin-right: auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
 `


### PR DESCRIPTION
This PR resolves the layout issue when the search results only contain documents with short names and chunk text.