### PR TITLE
[seta-react] Add Collapse All action

### DIFF
--- a/seta-react/src/api/admin/users.ts
+++ b/seta-react/src/api/admin/users.ts
@@ -44,7 +44,10 @@ export const useActiveUserInfos = () => {
 }
 
 const getAllAccounts = async (config?: AxiosRequestConfig): Promise<SetaAccount[]> => {
-  const { data } = await api.get<SetaAccount[]>(USERS_API_PATH, config)
+  const { data } = await api.get<SetaAccount[]>(USERS_API_PATH, {
+    baseURL: environment.baseUrl,
+    ...config
+  })
 
   return data
 }
@@ -52,6 +55,6 @@ const getAllAccounts = async (config?: AxiosRequestConfig): Promise<SetaAccount[
 export const useAllAccounts = () => {
   return useQuery({
     queryKey: AdminQueryKeys.AllUsers,
-    queryFn: ({ signal }) => getAllAccounts({ baseURL: environment.baseUrl, signal })
+    queryFn: ({ signal }) => getAllAccounts({ signal })
   })
 }

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryNode.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryNode.tsx
@@ -10,6 +10,7 @@ import { LibraryItemType } from '~/types/library/library-item'
 import NodeActions from './components/NodeActions'
 import { ROOT_ICON, FOLDER_ICON_OPEN, FOLDER_ICON, FILE_ICON } from './constants'
 import { useDocumentsTree } from './contexts/documents-tree-context'
+import { useRootActions } from './contexts/root-actions-context'
 import * as S from './styles'
 
 type Props = {
@@ -39,7 +40,10 @@ const LibraryNode = ({ className, item, isRoot }: Props) => {
 
   const selectChildRef = useRef(selectChild)
 
-  const { title, type, path } = item
+  const { registerIsExpandedSetter, unregisterIsExpandedSetter, collapseAllFolders } =
+    useRootActions()
+
+  const { id, title, type, path } = item
 
   const isDisabled = useMemo(() => disabledIds?.includes(item.id), [disabledIds, item.id])
 
@@ -50,6 +54,19 @@ const LibraryNode = ({ className, item, isRoot }: Props) => {
   const disabledStyle = isDisabled && S.disabled
 
   const itemStyle = [S.itemContainer, selectedStyle, editingStyle, disabledStyle]
+
+  useEffect(() => {
+    if (isRoot) {
+      return
+    }
+
+    // Register/unregister the isExpanded setter when the node is expanded/collapsed
+    if (isExpanded) {
+      registerIsExpandedSetter(id, setIsExpanded)
+    } else {
+      unregisterIsExpandedSetter(id)
+    }
+  }, [isExpanded, id, isRoot, registerIsExpandedSetter, unregisterIsExpandedSetter])
 
   useEffect(() => {
     if (willSelectId) {
@@ -101,6 +118,12 @@ const LibraryNode = ({ className, item, isRoot }: Props) => {
     }
   }
 
+  const handleCollapseAllFolders = () => {
+    if (isRoot) {
+      collapseAllFolders()
+    }
+  }
+
   const children = useMemo(() => {
     if (isDisabled) {
       return []
@@ -142,6 +165,7 @@ const LibraryNode = ({ className, item, isRoot }: Props) => {
       onNewFolderCreated={handleNewFolderCreated}
       onNewFolderPopoverChange={setIsEditing}
       onOptionsMenuChange={setIsEditing}
+      onCollapseAllFolders={handleCollapseAllFolders}
     />
   )
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryTree.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryTree.tsx
@@ -11,6 +11,7 @@ import { ErrorState, LoadingState, onSelectChild } from './common'
 import { ROOT_NODE } from './constants'
 import type { DocumentsTreeOptions } from './contexts/documents-tree-context'
 import { DocumentsTreeProvider } from './contexts/documents-tree-context'
+import { RootActionsProvider } from './contexts/root-actions-context'
 import LibraryNode from './LibraryNode'
 import * as S from './styles'
 
@@ -104,7 +105,7 @@ const LibraryTree = ({
         onSelect={handleSelect}
         selectChild={handleSelectChild}
       >
-        {content}
+        <RootActionsProvider>{content}</RootActionsProvider>
       </DocumentsTreeProvider>
     </div>
   )

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
@@ -5,6 +5,7 @@ import { LibraryItemType } from '~/types/library/library-item'
 import type { LibraryItem } from '~/types/library/library-item'
 
 import NewFolderAction from '../NewFolderAction'
+import RootActions from '../RootActions'
 
 // Lazy load the options menu action to avoid rendering it and the confirmation modals when not needed
 const OptionsMenuActionLazy = lazy(() => import('../OptionsMenuAction'))
@@ -17,32 +18,39 @@ type Props = {
   onNewFolderCreated?: (folderId: string) => void
   onNewFolderPopoverChange?: (open: boolean) => void
   onOptionsMenuChange?: (open: boolean) => void
+  onCollapseAllFolders?: () => void
 }
 
 const NodeActions = ({
   item,
   isRoot,
   noActionsMenu,
+  onCreatingNewFolder,
+  onNewFolderCreated,
   onNewFolderPopoverChange,
   onOptionsMenuChange,
-  onCreatingNewFolder,
-  onNewFolderCreated
+  onCollapseAllFolders
 }: Props) => {
   const hasActionMenu = !isRoot && !noActionsMenu
   const isFolder = item.type === LibraryItemType.Folder
+
+  const rootActions = isRoot && <RootActions onCollapseAll={onCollapseAllFolders} />
+
+  const folderActions = isFolder && (
+    <NewFolderAction
+      parent={item}
+      onPopoverChange={onNewFolderPopoverChange}
+      onCreatingNewFolder={onCreatingNewFolder}
+      onNewFolderCreated={onNewFolderCreated}
+    />
+  )
 
   return (
     <div data-actions>
       <Group spacing={2} ml="sm">
         <Tooltip.Group openDelay={300} closeDelay={200}>
-          {isFolder && (
-            <NewFolderAction
-              parent={item}
-              onPopoverChange={onNewFolderPopoverChange}
-              onCreatingNewFolder={onCreatingNewFolder}
-              onNewFolderCreated={onNewFolderCreated}
-            />
-          )}
+          {rootActions}
+          {folderActions}
 
           {hasActionMenu && (
             <Suspense fallback={null}>

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/RootActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/RootActions.tsx
@@ -1,0 +1,22 @@
+import { Group, Tooltip } from '@mantine/core'
+import { FaChevronUp } from 'react-icons/fa'
+
+import ColoredActionIcon from '~/components/ColoredActionIcon'
+
+type Props = {
+  onCollapseAll?: () => void
+}
+
+const RootActions = ({ onCollapseAll }: Props) => {
+  return (
+    <Group spacing={2}>
+      <Tooltip label="Collapse all folders">
+        <ColoredActionIcon color="gray" onClick={onCollapseAll}>
+          <FaChevronUp size={18} />
+        </ColoredActionIcon>
+      </Tooltip>
+    </Group>
+  )
+}
+
+export default RootActions

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RootActions'

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/root-actions-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/root-actions-context.tsx
@@ -1,0 +1,55 @@
+import { createContext, useCallback, useContext, useRef } from 'react'
+
+import type { ChildrenProp } from '~/types/children-props'
+
+type IsExpandedSetter = (isExpanded: boolean) => void
+
+type RootActionsContextProps = {
+  registerIsExpandedSetter: (id: string, setter: IsExpandedSetter) => void
+  unregisterIsExpandedSetter: (id: string) => void
+  collapseAllFolders: () => void
+}
+
+const RootActionsContext = createContext<RootActionsContextProps | undefined>(undefined)
+
+export const RootActionsProvider = ({ children }: ChildrenProp) => {
+  const isExpandedSettersRef = useRef(new Map<string, IsExpandedSetter>())
+
+  const registerIsExpandedSetter: RootActionsContextProps['registerIsExpandedSetter'] = useCallback(
+    (id, setter) => {
+      if (!isExpandedSettersRef.current.has(id)) {
+        isExpandedSettersRef.current.set(id, setter)
+      }
+    },
+    []
+  )
+
+  const unregisterIsExpandedSetter: RootActionsContextProps['unregisterIsExpandedSetter'] =
+    useCallback(id => {
+      isExpandedSettersRef.current.delete(id)
+    }, [])
+
+  const collapseAllFolders: RootActionsContextProps['collapseAllFolders'] = () => {
+    // Toggle all the setters to false, then clear the map
+    isExpandedSettersRef.current.forEach(setter => setter(false))
+    isExpandedSettersRef.current.clear()
+  }
+
+  const value: RootActionsContextProps = {
+    registerIsExpandedSetter,
+    unregisterIsExpandedSetter,
+    collapseAllFolders
+  }
+
+  return <RootActionsContext.Provider value={value}>{children}</RootActionsContext.Provider>
+}
+
+export const useRootActions = () => {
+  const context = useContext(RootActionsContext)
+
+  if (context === undefined) {
+    throw new Error('useRootActions must be used within a RootActionsProvider')
+  }
+
+  return context
+}


### PR DESCRIPTION
This PR adds the Library level action for collapsing all folders.

Also, corrects an unrelated ESLint warning for the React Query key dependency inside `admin/users`.