### PR TITLE
[seta-react] Remove taxonomy aggregations from query & filters

### DIFF
--- a/seta-react/src/api/search/documents.ts
+++ b/seta-react/src/api/search/documents.ts
@@ -61,8 +61,9 @@ const getDocuments = async (
   const defaultPayload: DocumentsPayload = {
     aggs: [
       AggregationType.DateYear,
-      AggregationType.CollectionReference,
-      AggregationType.Taxonomies
+      AggregationType.CollectionReference
+      // TODO: Re-enable this when the taxonomy aggregations are fixed
+      // AggregationType.Taxonomies
     ],
     n_docs: 100
   }

--- a/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
@@ -15,7 +15,6 @@ import { TextChunkValues } from '../../types/filters'
 import ApplyFilters from '../ApplyFilters'
 import DataSourceFilter from '../DataSourceFilter'
 import OtherFilter from '../OtherFilter/OtherFilter'
-import TaxonomyFilter from '../TaxonomyFilter'
 import TextChunkFilter from '../TextChunkFilter'
 import YearsRangeFilter from '../YearsRangeFilter'
 
@@ -37,7 +36,6 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
     rangeValue,
     setRangeValue,
     resourceNodes,
-    taxonomyNodes,
     status,
     dispatchStatus,
     otherItems,
@@ -201,7 +199,8 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
           </Accordion.Panel>
         </Accordion.Item>
 
-        <Accordion.Item value="taxonomy-tree">
+        {/* TODO: Re-enable this once the taxonomy aggregations are fixed */}
+        {/* <Accordion.Item value="taxonomy-tree">
           <Accordion.Control>
             <Text span>Taxonomies</Text>
           </Accordion.Control>
@@ -218,7 +217,7 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
               selectedKeys={taxonomySelectedKeys}
             />
           </Accordion.Panel>
-        </Accordion.Item>
+        </Accordion.Item> */}
 
         <Accordion.Item value="other">
           <Accordion.Control>


### PR DESCRIPTION
This PR removes the taxonomy aggregation from the Search query and the filters panel.

The code is commented out to be easily re-enabled once the API performance is fixed.