### PR TITLE
[seta-react] Add empty state for the Library

### DIFF
--- a/seta-react/src/components/SvgIcon/SvgIcon.tsx
+++ b/seta-react/src/components/SvgIcon/SvgIcon.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode, SVGAttributes } from 'react'
+import { forwardRef } from 'react'
+
+export interface SvgIconProps extends SVGAttributes<SVGElement> {
+  title?: string
+  children?: ReactNode
+}
+
+const SvgIcon = forwardRef<SVGSVGElement, SvgIconProps>(function SvgIcon(
+  { title, focusable = false, viewBox = '0 0 16 16', fill = 'none', role, children, ...rest },
+  ref
+) {
+  const accessibilityRole = role ?? (title && 'img')
+  const ariaHidden = title ? undefined : true
+
+  return (
+    <svg
+      ref={ref}
+      focusable={focusable}
+      viewBox={viewBox}
+      fill={fill}
+      role={accessibilityRole}
+      aria-hidden={ariaHidden}
+      {...rest}
+    >
+      {children}
+      {title && <title>{title}</title>}
+    </svg>
+  )
+})
+
+export default SvgIcon

--- a/seta-react/src/components/SvgIcon/index.ts
+++ b/seta-react/src/components/SvgIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SvgIcon'
+export * from './SvgIcon'

--- a/seta-react/src/icons/LargeArrow.tsx
+++ b/seta-react/src/icons/LargeArrow.tsx
@@ -1,0 +1,16 @@
+import { createSvgIcon } from '~/utils/svg-utils'
+
+const LargeArrow = createSvgIcon(
+  'LargeArrow',
+  { viewBox: '0 0 64 102', width: 64, height: 102 },
+  <path
+    fill="currentColor"
+    fillRule="evenodd"
+    stroke="strokeColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    d="m.672 34.531-.297-.656 35.719-32.64L62.609 42.03l-.437.563-22.656-7.89.125 6.64-.625 11.328-1.078 8.187-1.5 7.61-2.126 7.937-2.89 8.031-2.406 5.329-3.594 6.5-2.89 3.89-1.548.922-1.218-.61-.657-2.421-.25-9.89-.484-.844-2.328.296-8.469 2.844-2 .219-1.281-.656-.063-1.579.579-1.406 7.203-12.719 6.25-14.374h-.016l4.313-13.547 2.89-14.485Z"
+  />
+)
+
+export default LargeArrow

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/EmptyState.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text } from '@mantine/core'
+import { ImFilesEmpty } from 'react-icons/im'
+
+import { FOLDER_ICON } from '~/pages/SearchPageNew/components/documents/LibraryTree/constants'
+
+import LargeArrow from '~/icons/LargeArrow'
+
+import * as S from './styles'
+
+const PLUS_HINT = 'Click the Plus button to create a new folder'
+
+type Props = {
+  foldersOnly?: boolean
+  noArrow?: boolean
+  noDescription?: boolean
+  centerMessage?: boolean
+}
+
+const EmptyState = ({ foldersOnly, noArrow, noDescription, centerMessage }: Props) => {
+  const message = foldersOnly ? (
+    // Must use fragments to allow <br /> interpolation
+    <>
+      {PLUS_HINT} <br /> or save the document(s) at the root of your library.
+    </>
+  ) : (
+    <>
+      {PLUS_HINT} <br /> and save documents from the search results to organize your library.
+    </>
+  )
+
+  const icon = foldersOnly ? (
+    <div css={[S.icon, S.folderIcon]}>{FOLDER_ICON}</div>
+  ) : (
+    <ImFilesEmpty size={24} css={S.icon} />
+  )
+
+  return (
+    <Flex direction="column" align="center" justify="center" gap="sm" css={S.root}>
+      {icon}
+
+      <Text>Nothing here yet.</Text>
+
+      {!noArrow && <LargeArrow css={S.arrow} />}
+
+      {!noDescription && (
+        <Text fz="sm" color="gray.8" ta={centerMessage ? 'center' : undefined}>
+          {message}
+        </Text>
+      )}
+    </Flex>
+  )
+}
+
+export default EmptyState

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EmptyState'

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/EmptyState/styles.ts
@@ -1,0 +1,32 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  background-color: ${theme.colors.gray[0]};
+  border-radius: ${theme.radius.md};
+  border: 1px dashed ${theme.colors.gray[4]};
+  padding: ${theme.spacing.sm};
+  padding-top: ${theme.spacing.lg};
+  margin: ${theme.spacing.sm} ${theme.spacing.md};
+  white-space: normal;
+  position: relative;
+`
+
+export const icon: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[6]};
+  opacity: 0.8;
+`
+
+export const folderIcon = css`
+  font-size: 1.2rem;
+  line-height: 0;
+  scale: 1.25;
+`
+
+export const arrow: ThemedCSS = theme => css`
+  position: absolute;
+  scale: 0.8;
+  right: -20px;
+  top: -22px;
+  color: ${theme.colors.teal[6]};
+  stroke: ${theme.colors.teal[8]};
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
@@ -33,8 +33,12 @@ const NodeActions = ({
 }: Props) => {
   const hasActionMenu = !isRoot && !noActionsMenu
   const isFolder = item.type === LibraryItemType.Folder
+  const children = (item.type === LibraryItemType.Folder && item.children) || []
+  const isLibraryEmpty = isRoot && !children.length
 
-  const rootActions = isRoot && <RootActions onCollapseAll={onCollapseAllFolders} />
+  const rootActions = isRoot && (
+    <RootActions isLibraryEmpty={isLibraryEmpty} onCollapseAll={onCollapseAllFolders} />
+  )
 
   const folderActions = isFolder && (
     <NewFolderAction

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/RootActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/RootActions/RootActions.tsx
@@ -4,19 +4,20 @@ import { FaChevronUp } from 'react-icons/fa'
 import ColoredActionIcon from '~/components/ColoredActionIcon'
 
 type Props = {
+  isLibraryEmpty?: boolean
   onCollapseAll?: () => void
 }
 
-const RootActions = ({ onCollapseAll }: Props) => {
-  return (
-    <Group spacing={2}>
-      <Tooltip label="Collapse all folders">
-        <ColoredActionIcon color="gray" onClick={onCollapseAll}>
-          <FaChevronUp size={18} />
-        </ColoredActionIcon>
-      </Tooltip>
-    </Group>
+const RootActions = ({ isLibraryEmpty, onCollapseAll }: Props) => {
+  const collapseAll = !isLibraryEmpty && (
+    <Tooltip label="Collapse all folders">
+      <ColoredActionIcon color="gray" onClick={onCollapseAll}>
+        <FaChevronUp size={18} />
+      </ColoredActionIcon>
+    </Tooltip>
   )
+
+  return <Group spacing={2}>{collapseAll}</Group>
 }
 
 export default RootActions

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-node-content.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-node-content.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement } from 'react'
+import { css } from '@emotion/react'
+import { Collapse } from '@mantine/core'
+
+import ChevronToggleIcon from '~/components/ChevronToggleIcon'
+
+import EmptyState from '../components/EmptyState'
+import { FILE_ICON, FOLDER_ICON, FOLDER_ICON_OPEN, ROOT_ICON } from '../constants'
+
+type Args = {
+  isFolder: boolean
+  isRoot: boolean | undefined
+  isExpanded: boolean
+  foldersOnly?: boolean
+  folderContent: ReactElement[]
+}
+
+const toggleIconStyle = css`
+  grid-column: 1;
+`
+
+const useNodeContent = ({ isFolder, isRoot, isExpanded, foldersOnly, folderContent }: Args) => {
+  const isEmpty = folderContent.length === 0
+
+  const content = isFolder && (
+    <Collapse in={isExpanded}>
+      {isRoot && isEmpty ? (
+        <EmptyState foldersOnly={foldersOnly} noArrow={foldersOnly} centerMessage={foldersOnly} />
+      ) : (
+        folderContent
+      )}
+    </Collapse>
+  )
+
+  const toggleIcon = isFolder && (
+    <ChevronToggleIcon
+      start="right"
+      end="down"
+      size="sm"
+      toggled={isExpanded}
+      css={toggleIconStyle}
+    />
+  )
+
+  const icon = isRoot
+    ? ROOT_ICON
+    : isFolder
+    ? isExpanded
+      ? FOLDER_ICON_OPEN
+      : FOLDER_ICON
+    : FILE_ICON
+
+  return {
+    content,
+    toggleIcon,
+    icon
+  }
+}
+
+export default useNodeContent

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-node-events.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-node-events.tsx
@@ -1,0 +1,95 @@
+import type { Dispatch, SetStateAction } from 'react'
+
+import type { LibraryItem } from '~/types/library/library-item'
+
+type Args = {
+  item: LibraryItem
+  children: LibraryItem[]
+  selectable: boolean | undefined
+  toggleable: boolean | undefined
+  isRoot: boolean | undefined
+  isFolder: boolean
+  isDisabled: boolean | undefined
+  isExpanded: boolean
+  selected?: LibraryItem
+  onSelect?: (value?: LibraryItem) => void
+  setWillSelectId: Dispatch<SetStateAction<string | null>>
+  setIsExpanded: Dispatch<SetStateAction<boolean>>
+  setIsLoading: Dispatch<SetStateAction<boolean>>
+  collapseAllFolders: () => void
+}
+
+const useNodeEvents = ({
+  item,
+  children,
+  selectable,
+  toggleable,
+  isRoot,
+  isFolder,
+  isDisabled,
+  isExpanded,
+  selected,
+  onSelect,
+  setWillSelectId,
+  setIsExpanded,
+  setIsLoading,
+  collapseAllFolders
+}: Args) => {
+  const handleTitleClick = () => {
+    if (isDisabled) {
+      return
+    }
+
+    if (isFolder) {
+      setIsExpanded(prev => !prev)
+    }
+
+    if (selectable) {
+      if (toggleable) {
+        const isAlreadySelected = selected?.id === item.id
+        const itemValue = isAlreadySelected ? undefined : item
+
+        onSelect?.(itemValue)
+
+        return
+      }
+
+      if (selected?.id !== item.id) {
+        onSelect?.(item)
+      }
+    }
+  }
+
+  const handleCreatingNewFolder = () => {
+    setIsLoading(true)
+
+    // Collapse the node to correctly show the new folder after it's created
+    if (isExpanded && !isRoot && !children.length) {
+      setIsExpanded(false)
+    }
+  }
+
+  const handleNewFolderCreated = (folderId: string) => {
+    setIsLoading(false)
+    setIsExpanded(true)
+
+    if (selectable) {
+      setWillSelectId(folderId)
+    }
+  }
+
+  const handleCollapseAllFolders = () => {
+    if (isRoot) {
+      collapseAllFolders()
+    }
+  }
+
+  return {
+    handleTitleClick,
+    handleCreatingNewFolder,
+    handleNewFolderCreated,
+    handleCollapseAllFolders
+  }
+}
+
+export default useNodeEvents

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/styles.ts
@@ -42,6 +42,10 @@ export const itemContainer: ThemedCSS = theme => css`
   &:active:not(:focus-within) {
     transform: translateY(1px);
   }
+
+  &[data-top-actions] [data-actions] {
+    display: block;
+  }
 `
 
 export const editing: ThemedCSS = theme => css`
@@ -62,10 +66,6 @@ export const disabled: ThemedCSS = theme => css`
   border: 1px dashed ${theme.colors.gray[5]};
   opacity: 0.5;
   pointer-events: none;
-`
-
-export const toggleIcon = css`
-  grid-column: 1;
 `
 
 export const icon: ThemedCSS = theme => css`
@@ -112,5 +112,3 @@ export const tooltipStyles = createStyles(() => ({
     whiteSpace: 'normal'
   }
 }))
-
-export const editField = css``

--- a/seta-react/src/pages/SearchWithFilters/components/SidePanel/SidePanel.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/SidePanel/SidePanel.tsx
@@ -49,7 +49,7 @@ const SidePanel = ({
         />
       </ToggleSection>
 
-      <ToggleSection icon={<IconSearch size={20} />} color="grape" title="My Search">
+      <ToggleSection icon={<IconSearch size={20} />} color="grape" title="My Searches">
         <UnderDevelopment variant="coming-soon" />
       </ToggleSection>
 

--- a/seta-react/src/utils/svg-utils.tsx
+++ b/seta-react/src/utils/svg-utils.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode, Ref } from 'react'
+import { forwardRef, memo } from 'react'
+
+import type { SvgIconProps } from '../components/SvgIcon'
+import SvgIcon from '../components/SvgIcon'
+
+/**
+ * Creates an SVG icon component.
+ *
+ * @param displayName The name of the icon, used to generate the display name
+ * @param iconProps The initial props to pass to the icon component
+ * @param path The SVG path element to render
+ * @returns The SVG icon
+ */
+export const createSvgIcon = (
+  displayName: string,
+  iconProps: Partial<SvgIconProps>,
+  path: ReactNode
+): typeof SvgIcon => {
+  const iconName = `${displayName}Icon`
+
+  const Icon = (props: SvgIconProps, ref: Ref<SVGSVGElement>) => (
+    <SvgIcon ref={ref} {...iconProps} {...props}>
+      {path}
+    </SvgIcon>
+  )
+
+  Icon.displayName = iconName
+
+  return memo(forwardRef<SVGSVGElement, SvgIconProps>(Icon))
+}


### PR DESCRIPTION
This PR implements the empty state for the Library and folder selector.

It also introduces a utility function and component to allow us to easily use SVG icons/graphics as React components.