### PR TITLE
[seta-react] Add notification utils

### DIFF
--- a/seta-react/src/styles/keyframe-animations.ts
+++ b/seta-react/src/styles/keyframe-animations.ts
@@ -9,3 +9,44 @@ export const slideDown = keyframes({
   '0%': { transform: 'translateY(-100%)', opacity: 0 },
   '100%': { transform: 'translateY(0)', opacity: 1 }
 })
+
+export const slideRight = keyframes({
+  '0%': { transform: 'translateX(-100%)', opacity: 0 },
+  '100%': { transform: 'translateX(0)', opacity: 1 }
+})
+
+export const rollSlideRight = keyframes({
+  '0%': { transform: 'translateX(-100%) rotate(-360deg)', opacity: 0 },
+  '100%': { transform: 'translateX(0) rotate(0)', opacity: 1 }
+})
+
+export const growAndRestore = keyframes({
+  '0%': { transform: 'scale(0)', opacity: 0 },
+  '50%': { transform: 'scale(1.2)' },
+  '100%': { transform: 'scale(1)', opacity: 1 }
+})
+
+export const growBounce = keyframes({
+  '0%': { transform: 'scale(0)' },
+  '50%': { transform: 'scale(1.2)' },
+  '65%': { transform: 'scale(1.1)' },
+  '80%': { transform: 'scale(1.2)' },
+  '100%': { transform: 'scale(1)' }
+})
+
+export const wiggleX = keyframes({
+  '0%': { transform: 'translateX(0)', opacity: 0 },
+  '20%': { transform: 'translateX(-3px)' },
+  '40%': { transform: 'translateX(0)' },
+  '60%': { transform: 'translateX(-3px)' },
+  '75%': { transform: 'translateX(0)' },
+  '90%': { transform: 'translateX(-2px)' },
+  '100%': { transform: 'translateX(0)', opacity: 1 }
+})
+
+export const turnAndGrow = keyframes({
+  '0%': { transform: 'rotate(0) scale(0)' },
+  '20%': { transform: 'rotate(0) scale(1)' },
+  '50%': { transform: 'rotate(180deg) scale(0.7)' },
+  '100%': { transform: 'rotate(360deg) scale(1)' }
+})

--- a/seta-react/src/utils/notifications/common.ts
+++ b/seta-react/src/utils/notifications/common.ts
@@ -1,0 +1,24 @@
+import type { Keyframes } from '@emotion/react'
+import type { DefaultMantineColor } from '@mantine/core'
+
+import { growAndRestore, rollSlideRight, wiggleX } from '~/styles/keyframe-animations'
+
+export type NotificationType = 'info' | 'success' | 'error'
+
+export const COLOR: Record<NotificationType, DefaultMantineColor> = {
+  info: 'blue',
+  success: 'teal',
+  error: 'red'
+}
+
+export const SVG_SCALE: Record<NotificationType, number> = {
+  info: 1.1,
+  success: 1.1,
+  error: 1
+}
+
+export const ANIMATION: Record<NotificationType, Keyframes> = {
+  info: growAndRestore,
+  success: rollSlideRight,
+  error: wiggleX
+}

--- a/seta-react/src/utils/notifications/index.ts
+++ b/seta-react/src/utils/notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './notifications'

--- a/seta-react/src/utils/notifications/notifications.tsx
+++ b/seta-react/src/utils/notifications/notifications.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react'
+import { notifications as n } from '@mantine/notifications'
+import {
+  IconAlertOctagonFilled,
+  IconCircleCheckFilled,
+  IconInfoHexagonFilled
+} from '@tabler/icons-react'
+
+import { COLOR, type NotificationType } from './common'
+import { getStyles } from './styles'
+
+const AUTOCLOSE_DURATION = 5000
+
+type Args = {
+  description?: ReactNode
+  autoClose?: number | boolean
+  withoutCloseButton?: boolean
+  onClose?: () => void
+  onOpen?: () => void
+}
+
+const showNotification = (
+  message: ReactNode,
+  type: NotificationType,
+  icon: ReactNode,
+  args?: Args
+) => {
+  const { description, autoClose, withoutCloseButton, ...rest } = args ?? {}
+
+  const color = COLOR[type]
+  const styles = getStyles(type)
+
+  // If the description is provided, swap the message and title
+  const finalMessage = description ? description : message
+  const finalTitle = description ? message : null
+
+  // If autoClose is not provided, use the default duration for success and info notifications
+  const finalAutoClose = autoClose ?? (type === 'error' ? false : AUTOCLOSE_DURATION)
+
+  return n.show({
+    message: finalMessage,
+    title: finalTitle,
+    autoClose: finalAutoClose,
+    withCloseButton: !withoutCloseButton,
+    color,
+    icon,
+    styles,
+    radius: 'md',
+    ...rest
+  })
+}
+
+const showInfo = (message: ReactNode, args?: Args) =>
+  showNotification(message, 'info', <IconInfoHexagonFilled />, args)
+
+const showSuccess = (message: ReactNode, args?: Args) =>
+  showNotification(message, 'success', <IconCircleCheckFilled />, args)
+
+const showError = (message: ReactNode, args?: Args) =>
+  showNotification(message, 'error', <IconAlertOctagonFilled />, args)
+
+export const notifications = {
+  showInfo,
+  showSuccess,
+  showError
+}

--- a/seta-react/src/utils/notifications/styles.ts
+++ b/seta-react/src/utils/notifications/styles.ts
@@ -1,0 +1,43 @@
+import type { NotificationProps } from '@mantine/notifications'
+
+import type { NotificationType } from './common'
+import { SVG_SCALE, ANIMATION, COLOR } from './common'
+
+export const getStyles = (type: NotificationType): NotificationProps['styles'] => {
+  const color = COLOR[type]
+  const svgScale = SVG_SCALE[type]
+  const animation = ANIMATION[type]
+
+  return theme => ({
+    root: {
+      borderColor: theme.colors[color][6],
+      backgroundColor: theme.colors[color][0],
+      boxShadow: '3px 3px 6px 0px rgba(0,0,0, 0.2)',
+      padding: '0.8rem',
+
+      '&[data-with-icon]': {
+        paddingLeft: '0.8rem'
+      }
+    },
+
+    icon: {
+      marginRight: '0.8rem',
+      backgroundColor: 'white',
+      color: theme.colors[color][6],
+      transform: 'scale(0)',
+      animation: `${animation} 500ms 50ms ease forwards`,
+
+      svg: {
+        width: 30,
+        height: 30,
+        transform: `scale(${svgScale})`
+      }
+    },
+
+    closeButton: {
+      '&:hover': {
+        backgroundColor: theme.white
+      }
+    }
+  })
+}


### PR DESCRIPTION
This PR introduces the `notification` utility which allows to show info, success and error notifications in a unified manner.