### PR TITLE
[seta-react] Add Library document link action

### DIFF
--- a/seta-react/src/api/search/library.ts
+++ b/seta-react/src/api/search/library.ts
@@ -28,7 +28,7 @@ export type SaveDocumentsPayload = {
   documents: {
     documentId: string
     title: string
-    link?: string
+    link?: string | null
   }[]
 }
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
@@ -64,7 +64,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
       icon: <IconWallet size={22} />,
       color: 'orange',
       tooltip: 'Save to my documents',
-      onClick: () => handleSave([{ id: document_id, title }])
+      onClick: () => handleSave([{ id: document_id, title, link: link_origin }])
     },
     {
       name: 'stage-doc',
@@ -76,7 +76,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
       toggledColor: 'teal',
       toggledTooltip: 'Remove from staged documents',
       toggledIcon: <FiCheck size={22} style={{ marginTop: 2 }} />,
-      onToggle: staged => toggleStaged(document_id, title, staged)
+      onToggle: staged => toggleStaged(document_id, title, link_origin, staged)
     }
   ]
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/DocumentLinkAction/DocumentLinkAction.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/DocumentLinkAction/DocumentLinkAction.tsx
@@ -1,0 +1,32 @@
+import { FiExternalLink } from 'react-icons/fi'
+
+import ColoredActionIcon from '~/components/ColoredActionIcon'
+
+import type { LibraryItem } from '~/types/library/library-item'
+import { LibraryItemType } from '~/types/library/library-item'
+
+type Props = {
+  item: LibraryItem
+}
+
+const DocumentLinkAction = ({ item }: Props) => {
+  if (item.type !== LibraryItemType.Document || !item.link) {
+    return null
+  }
+
+  const handleClick = () => {
+    if (!item.link) {
+      return
+    }
+
+    window.open(item.link, '_blank')
+  }
+
+  return (
+    <ColoredActionIcon color="blue" tooltip="Open external document link" onClick={handleClick}>
+      <FiExternalLink size={18} strokeWidth={3} />
+    </ColoredActionIcon>
+  )
+}
+
+export default DocumentLinkAction

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/DocumentLinkAction/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/DocumentLinkAction/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DocumentLinkAction'

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NodeActions/NodeActions.tsx
@@ -4,6 +4,7 @@ import { Group, Tooltip } from '@mantine/core'
 import { LibraryItemType } from '~/types/library/library-item'
 import type { LibraryItem } from '~/types/library/library-item'
 
+import DocumentLinkAction from '../DocumentLinkAction'
 import NewFolderAction from '../NewFolderAction'
 import RootActions from '../RootActions'
 
@@ -49,12 +50,15 @@ const NodeActions = ({
     />
   )
 
+  const documentActions = !isFolder && <DocumentLinkAction item={item} />
+
   return (
     <div data-actions>
       <Group spacing={2} ml="sm">
         <Tooltip.Group openDelay={300} closeDelay={200}>
           {rootActions}
           {folderActions}
+          {documentActions}
 
           {hasActionMenu && (
             <Suspense fallback={null}>

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/OptionsMenuAction/OptionsMenuAction.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/OptionsMenuAction/OptionsMenuAction.tsx
@@ -29,7 +29,7 @@ const OptionsMenuAction = ({ item, isLoading, onMenuChange }: Props) => {
       action={{
         icon: <BsThreeDotsVertical size={18} strokeWidth={0.5} />,
         color: 'gray.7',
-        tooltip: isFolder ? 'Other actions' : 'Actions',
+        tooltip: 'Actions',
         loading: isLoading,
         active: isLoading,
         onClick: () => setIsOpen(true)

--- a/seta-react/src/pages/SearchPageNew/contexts/staged-documents-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/contexts/staged-documents-context.tsx
@@ -9,7 +9,14 @@ import { storage } from '~/utils/storage-utils'
 
 type StagedDocumentsContextProps = {
   isStaged: (documentId: string) => boolean
-  toggleStaged: (documentId: string, documentTitle: string, staged: boolean) => void
+
+  toggleStaged: (
+    documentId: string,
+    documentTitle: string,
+    link: string | undefined | null,
+    staged: boolean
+  ) => void
+
   removeStaged: (documentId: string | string[]) => void
   clearStaged: () => void
   stagedDocuments: StagedDocument[]
@@ -41,10 +48,11 @@ export const StagedDocumentsProvider = ({ children }: ChildrenProp) => {
   )
 
   const toggleStaged: StagedDocumentsContextProps['toggleStaged'] = useCallback(
-    (documentId, documentTitle, staged) => {
+    (documentId, documentTitle, link, staged) => {
       const doc: StagedDocument = {
         id: documentId,
-        title: documentTitle
+        title: documentTitle,
+        link
       }
 
       const newStagedDocs = toggleArrayValue(stagedDocuments, doc, staged, 'id')

--- a/seta-react/src/pages/SearchPageNew/hooks/use-save-docs-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/hooks/use-save-docs-modal.tsx
@@ -50,7 +50,7 @@ const useSaveDocsModal = ({ selectedDocs, clearSelectedDocs, removeStaged }: Arg
     mutate(
       {
         parentId: target.id === 'root' ? null : target.id,
-        documents: docs.map(({ id, title }) => ({ documentId: id, title }))
+        documents: docs.map(({ id, title, link }) => ({ documentId: id, title, link }))
       },
       {
         onSuccess: () => {

--- a/seta-react/src/pages/SearchPageNew/types/search.ts
+++ b/seta-react/src/pages/SearchPageNew/types/search.ts
@@ -28,4 +28,5 @@ export type SearchState = {
 export type StagedDocument = {
   id: string
   title: string
+  link?: string | null
 }


### PR DESCRIPTION
This PR adds the "open link" action for all the documents in the Library that have the `link_origin` property available.
Clicking the action button opens the link in a new tab.