### PR TITLE
Add community_id info in resource permission lists

### DIFF
--- a/seta-ui/seta_flask_server/blueprints/authorization/logic/token_info_logic.py
+++ b/seta-ui/seta_flask_server/blueprints/authorization/logic/token_info_logic.py
@@ -8,18 +8,19 @@ def get_resource_permissions(user: SetaUser, resourcesBroker: IResourcesBroker) 
     permissions = {"add": [], "delete": [], "view": []}
 
     if user is not None:
-        if user.resource_scopes is not None:
+        if user.resource_scopes is not None:            
             data_add_resources = filter(lambda r: r.scope.lower() == ResourceScopeConstants.DataAdd.lower(), user.resource_scopes)                        
-            permissions["add"] = [obj.id for obj in data_add_resources]
+            permissions["add"] = [{ "community_id": None, "resource_id": obj.id } for obj in data_add_resources]
             
             data_delete_resources = filter(lambda r: r.scope.lower() == ResourceScopeConstants.DataDelete.lower(), user.resource_scopes)                        
-            permissions["delete"] = [obj.id for obj in data_delete_resources]
+            permissions["delete"] = [{ "community_id": None, "resource_id": obj.id } for obj in data_delete_resources]
 
         #get queryable resource
         queryable_resources = resourcesBroker.get_all_queryable_by_user_id(user.user_id)
-        permissions["view"] = [qr.resource_id for qr in queryable_resources]
+        permissions["view"] = [{ "community_id": qr.community_id, "resource_id": qr.resource_id } for qr in queryable_resources]
 
         #get representative resources
-        permissions["representatives"] = resourcesBroker.get_ids_by_member_id_and_type(user_id=user.user_id, type=ResourceTypeConstants.Representative)
+        representatives = resourcesBroker.get_all_by_member_id_and_type(user_id=user.user_id, type=ResourceTypeConstants.Representative)
+        permissions["representatives"] = [{ "community_id": r.community_id, "resource_id": r.resource_id } for r in representatives]
 
     return permissions

--- a/seta-ui/seta_flask_server/factory_auth.py
+++ b/seta-ui/seta_flask_server/factory_auth.py
@@ -40,7 +40,7 @@ def create_app(config_object):
         }
         return additional_claims
     
-     # Callback function to check if a JWT exists in the database block list
+    #Callback function to check if a JWT exists in the database block list
     @jwt.token_in_blocklist_loader
     def check_if_token_revoked(jwt_header, jwt_payload: dict) -> bool:
         jti = jwt_payload["jti"]

--- a/seta-ui/seta_flask_server/repository/interfaces/resources_broker.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/resources_broker.py
@@ -21,9 +21,9 @@ class IResourcesBroker(Interface):
         '''Retrieve all resource ids that can be queried by user id'''
         pass
 
-    def get_ids_by_member_id_and_type(self, user_id:str, type: str) -> list[str]:
+    def get_all_by_member_id_and_type(self, user_id:str, type: str) -> list[ResourceModel]:
         '''
-        Retrieve all resource ids within user memberships filter by type
+        Retrieve all resources within user memberships filter by type
 
         :param user_id:
             User identifier

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/db_resources_broker.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/db_resources_broker.py
@@ -105,7 +105,7 @@ class ResourcesBroker(implements(IResourcesBroker)):
         resources = self.collection.find(filter)
         return [ResourceModel.from_db_json(c) for c in resources]
     
-    def get_ids_by_member_id_and_type(self, user_id:str, type: str) -> list[str]:
+    def get_all_by_member_id_and_type(self, user_id:str, type: str) -> list[ResourceModel]:
         community_ids = self._get_membership_communities(user_id)
 
         filter = {
@@ -114,9 +114,8 @@ class ResourcesBroker(implements(IResourcesBroker)):
                     "type": type
                 }
         
-        resources = self.collection.find(filter, {"resource_id": 1})
-        #return resource ids
-        return [c["resource_id"] for c in resources]
+        resources = self.collection.find(filter)
+        return [ResourceModel.from_db_json(c) for c in resources]
 
     def get_all_by_community_id(self, community_id:str) -> list[ResourceModel]:
         '''Retrieve all resources belonging to the community id'''


### PR DESCRIPTION
Add {community_id, resource_id} in the resource_permissions list at authorization/v1//token_info endpoint.

Note: community_id is not set for 'add' and 'delete' lists.

Example:
'resource_permissions': {
'add': [{'community_id': None, 'resource_id': 'pubsy'}, {'community_id': None, 'resource_id': 'cordis'}, {'community_id': None, 'resource_id': 'seta-representative'}],
'delete': [{'community_id': None, 'resource_id': 'pubsy'}, {'community_id': None, 'resource_id': 'cordis'}, {'community_id': None, 'resource_id': 'seta-representative'}],
'view': [{'community_id': 'seta', 'resource_id': 'pubsy'}, {'community_id': 'seta', 'resource_id': 'cordis'}],
'representatives': [{'community_id': 'seta', 'resource_id': 'seta-representative'}]}