### PR TITLE
[seta-react] Add Library export

### DIFF
--- a/seta-react/package.json
+++ b/seta-react/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@formkit/auto-animate": "^0.7.0",
+    "@hello-pangea/dnd": "^16.3.0",
     "@mantine/core": "^6.0.6",
     "@mantine/dates": "^6.0.6",
     "@mantine/dropzone": "^6.0.6",

--- a/seta-react/src/api/search/export.ts
+++ b/seta-react/src/api/search/export.ts
@@ -1,0 +1,84 @@
+import type { QueryKey } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import type { AxiosRequestConfig } from 'axios'
+
+import api from '~/api'
+import {
+  ExportMimeType,
+  type ExportField,
+  type ExportFormatKey
+} from '~/types/library/library-export'
+import { getTimestamp } from '~/utils/date-utils'
+import { downloadFile } from '~/utils/file-utils'
+import { toKebabCase } from '~/utils/string-utils'
+
+const FIELDS_CATALOG_API_PATH = '/export/catalog'
+const EXPORT_API_PATH = '/export'
+
+const EXPORT_FILE_NAME_PREFIX = 'seta-export'
+
+export type FieldsCatalogResponse = {
+  fields_catalog: ExportField[]
+}
+
+type UseFieldsCatalogArgs = {
+  enabled?: boolean
+  onSuccess?: (data: FieldsCatalogResponse) => void
+}
+
+export type ExportMetaPayload = {
+  ids: string[]
+  fields: string[]
+  format: ExportFormatKey
+}
+
+export const fieldsCatalogQueryKey: QueryKey = ['fields-catalog']
+
+/* GET FIELDS CATALOG */
+
+const getFieldsCatalog = async (config?: AxiosRequestConfig): Promise<FieldsCatalogResponse> => {
+  const { data } = await api.get<FieldsCatalogResponse>(FIELDS_CATALOG_API_PATH, config)
+
+  return data
+}
+
+export const useFieldsCatalog = (args?: UseFieldsCatalogArgs) => {
+  const { enabled = true, ...rest } = args ?? {}
+
+  return useQuery({
+    queryKey: fieldsCatalogQueryKey,
+    queryFn: getFieldsCatalog,
+    enabled,
+    ...rest
+  })
+}
+
+/* EXPORT METADATA */
+
+export const exportMeta = async (
+  { ids, fields, format }: ExportMetaPayload,
+  reference?: string,
+  config?: AxiosRequestConfig
+) => {
+  const mimeType = ExportMimeType[format].mimeType
+
+  const { data } = await api.post<Blob>(
+    EXPORT_API_PATH,
+    { ids, fields },
+    {
+      ...config,
+      responseType: 'blob',
+      headers: {
+        Accept: mimeType
+      }
+    }
+  )
+
+  // Generate file name based on timestamp, optional reference, and format
+  const timestamp = getTimestamp()
+  const referenceHint = reference ? `-${toKebabCase(reference)}` : ''
+
+  const fileName = `${EXPORT_FILE_NAME_PREFIX}${referenceHint}-${timestamp}.${format}`
+
+  downloadFile(data, fileName)
+}

--- a/seta-react/src/components/ActionLink/ActionLink.tsx
+++ b/seta-react/src/components/ActionLink/ActionLink.tsx
@@ -1,0 +1,15 @@
+import type { ComponentPropsWithRef } from 'react'
+import { Button } from '@mantine/core'
+
+import * as S from './styles'
+
+// Can't use Mantine's ButtonProps because it doesn't expose the base events
+type ButtonProps = ComponentPropsWithRef<typeof Button<'button'>>
+
+type Props = Omit<ButtonProps, 'radius | variant'>
+
+const ActionLink = (props: Props) => {
+  return <Button {...props} variant="white" css={S.root} />
+}
+
+export default ActionLink

--- a/seta-react/src/components/ActionLink/index.ts
+++ b/seta-react/src/components/ActionLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActionLink'

--- a/seta-react/src/components/ActionLink/styles.ts
+++ b/seta-react/src/components/ActionLink/styles.ts
@@ -1,0 +1,16 @@
+import { css } from '@emotion/react'
+
+const ICON_MARGIN = '0.35rem'
+
+export const root: ThemedCSS = theme => css`
+  padding: 0;
+  height: auto;
+
+  .seta-Button-leftIcon {
+    margin-right: ${ICON_MARGIN};
+  }
+
+  .seta-Button-rightIcon {
+    margin-left: ${ICON_MARGIN};
+  }
+`

--- a/seta-react/src/components/DefaultModal/DefaultModal.tsx
+++ b/seta-react/src/components/DefaultModal/DefaultModal.tsx
@@ -1,46 +1,30 @@
-import type { ForwardedRef, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import type { ModalProps } from '@mantine/core'
-import { Text, Flex, Modal, ActionIcon, ScrollArea } from '@mantine/core'
-import { usePrevious } from '@mantine/hooks'
+import { Text, Flex, Modal, ActionIcon } from '@mantine/core'
 import { FiMaximize, FiMinimize } from 'react-icons/fi'
-
-import useScrolled from '~/hooks/use-scrolled'
 
 import * as S from './styles'
 
-const SCROLL_THRESHOLD = 12
-
-type Props = ModalProps & {
+export type DefaultModalProps = ModalProps & {
   icon?: ReactNode
   actions?: ReactNode
   info?: ReactNode
-  scrollableRef?: ForwardedRef<HTMLDivElement | null>
-  noScrollShadow?: boolean
   fullScreenToggle?: boolean
 }
 
-const ScrollModal = ({
+const DefaultModal = ({
   title,
   icon,
   actions,
   info,
-  scrollableRef,
-  noScrollShadow,
   fullScreenToggle,
   fullScreen = false,
   opened,
   children,
   ...props
-}: Props) => {
+}: DefaultModalProps) => {
   const [isFullScreen, setFullScreen] = useState(fullScreen)
-
-  const { scrolled, setScrolled, handleScrollChange } = useScrolled({
-    delta: SCROLL_THRESHOLD,
-    preventSetScrolled: () => noScrollShadow
-  })
-
-  const prevOpened = usePrevious(opened)
 
   const { classes: modalStyles } = S.modalStyles()
 
@@ -48,13 +32,6 @@ const ScrollModal = ({
   useEffect(() => {
     setFullScreen(fullScreen)
   }, [fullScreen, setFullScreen])
-
-  // Reset scrolled state when modal is opened
-  useEffect(() => {
-    if (opened && !prevOpened) {
-      setScrolled(false)
-    }
-  }, [opened, prevOpened, setScrolled])
 
   const toggleFullScreen = () => setFullScreen(prev => !prev)
 
@@ -106,22 +83,15 @@ const ScrollModal = ({
       css={S.root}
       classNames={{ ...modalStyles }}
       closeButtonProps={{ 'aria-label': 'Close modal' }}
-      data-scrolled={noScrollShadow ? undefined : scrolled}
       data-fullscreen={isFullScreen}
     >
-      <ScrollArea.Autosize
-        viewportRef={scrollableRef}
-        css={S.scrollArea}
-        onScrollPositionChange={handleScrollChange}
-      >
-        <div css={S.content} className="seta-ScrollModal-content">
-          {children}
-        </div>
-      </ScrollArea.Autosize>
+      <div css={S.content} className="seta-DefaultModal-content">
+        {children}
+      </div>
 
       {actionsEl}
     </Modal>
   )
 }
 
-export default ScrollModal
+export default DefaultModal

--- a/seta-react/src/components/DefaultModal/index.ts
+++ b/seta-react/src/components/DefaultModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DefaultModal'

--- a/seta-react/src/components/DefaultModal/styles.ts
+++ b/seta-react/src/components/DefaultModal/styles.ts
@@ -1,0 +1,99 @@
+import { css } from '@emotion/react'
+import { createStyles, getStylesRef } from '@mantine/core'
+
+export const modalStyles = createStyles(theme => ({
+  header: {
+    ref: getStylesRef('header'),
+    borderBottom: `1px solid ${theme.colors.gray[3]}`,
+    transition: `box-shadow 200ms ${theme.transitionTimingFunction}`,
+    zIndex: 1002,
+
+    '.seta-CloseButton-root': {
+      transform: 'scale(1.2)'
+    }
+  },
+
+  title: {
+    display: 'flex',
+    flex: 1
+  },
+
+  root: {
+    [`&[data-scrolled='true'] .${getStylesRef('header')}`]: {
+      boxShadow: theme.shadows.sm,
+      borderBottomColor: theme.colors.gray[4]
+    }
+  },
+
+  content: {
+    maxHeight: 'initial',
+    display: 'grid',
+    gridTemplateRows: 'auto 1fr'
+  },
+
+  body: {
+    padding: 0,
+    display: 'grid',
+    gridTemplateRows: '1fr auto',
+    overflow: 'hidden',
+    maxHeight: '75vh'
+  }
+}))
+
+export const root = css`
+  .seta-Modal-inner {
+    left: 0;
+  }
+
+  &[data-fullscreen='true'] {
+    .seta-Modal-body {
+      max-height: 100vh;
+    }
+
+    .seta-Modal-content {
+      flex-basis: 100vw;
+
+      .seta-ScrollArea-root {
+        max-height: 100vh;
+      }
+    }
+  }
+`
+
+export const scrollArea: ThemedCSS = theme => css`
+  min-height: 0;
+  overflow: hidden;
+  background-color: ${theme.colors.gray[0]};
+
+  .seta-ScrollArea-root {
+    max-height: 60vh;
+
+    .seta-ScrollArea-scrollbar {
+      z-index: 10;
+
+      &[data-state='visible'] {
+        &:hover {
+          background-color: ${theme.fn.rgba(theme.colors.gray[3], 0.8)};
+        }
+      }
+    }
+  }
+`
+
+export const icon: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[5]};
+  font-size: 1.5rem;
+  min-width: 1.5rem;
+  line-height: 0;
+`
+
+export const content: ThemedCSS = theme => css`
+  padding: ${theme.spacing.lg} ${theme.spacing.xl};
+  min-height: 14rem;
+  background-color: ${theme.colors.gray[0]};
+`
+
+export const actions: ThemedCSS = theme => css`
+  padding: ${theme.spacing.md};
+  border-top: 1px solid ${theme.colors.gray[3]};
+`

--- a/seta-react/src/components/InfoTitle/InfoTitle.tsx
+++ b/seta-react/src/components/InfoTitle/InfoTitle.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import { Group, Text, Tooltip } from '@mantine/core'
+import type { TooltipBaseProps } from '@mantine/core/lib/Tooltip/Tooltip.types'
+import { IconInfoCircle } from '@tabler/icons-react'
+
+import * as S from './styles'
+
+type TooltipOptions = {
+  width?: TooltipBaseProps['width']
+  multiline?: TooltipBaseProps['multiline']
+  withinPortal?: TooltipBaseProps['withinPortal']
+  position?: TooltipBaseProps['position']
+  zIndex?: TooltipBaseProps['zIndex']
+}
+
+type Props = {
+  children: ReactNode
+  tooltip?: ReactNode
+  tooltipOptions?: TooltipOptions
+}
+
+const InfoTitle = ({ children, tooltip, tooltipOptions }: Props) => {
+  return (
+    <Group spacing="0.5rem">
+      <Text fz="lg">{children}</Text>
+
+      {tooltip && (
+        <Tooltip label={tooltip} {...tooltipOptions}>
+          <IconInfoCircle css={S.info} />
+        </Tooltip>
+      )}
+    </Group>
+  )
+}
+
+export default InfoTitle

--- a/seta-react/src/components/InfoTitle/index.ts
+++ b/seta-react/src/components/InfoTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InfoTitle'

--- a/seta-react/src/components/InfoTitle/styles.ts
+++ b/seta-react/src/components/InfoTitle/styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@emotion/react'
+
+export const info: ThemedCSS = theme => css`
+  color: ${theme.colors.gray[5]};
+  cursor: help;
+`

--- a/seta-react/src/hooks/use-scrolled.ts
+++ b/seta-react/src/hooks/use-scrolled.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-type Position = {
+export type Position = {
   x: number
   y: number
 }

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/ExportModal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/ExportModal.tsx
@@ -1,0 +1,198 @@
+import { useMemo, useState } from 'react'
+import type { ModalProps } from '@mantine/core'
+import { Group, Button } from '@mantine/core'
+import { useListState } from '@mantine/hooks'
+import { FiCornerUpRight } from 'react-icons/fi'
+
+import CancelButton from '~/components/CancelButton'
+import DefaultModal from '~/components/DefaultModal'
+import { STORAGE_KEY } from '~/pages/SearchPageNew/utils/constants'
+
+import type { ExportMetaPayload } from '~/api/search/export'
+import { exportMeta, useFieldsCatalog } from '~/api/search/export'
+import type { Position } from '~/hooks/use-scrolled'
+import type {
+  ExportFormatKey,
+  ExportField,
+  ExportStorage,
+  LibraryExport
+} from '~/types/library/library-export'
+import { notifications } from '~/utils/notifications'
+import { storage } from '~/utils/storage-utils'
+
+import AvailableFieldsTitle from './components/AvailableFieldsTitle'
+import ExportFormat from './components/ExportFormat'
+import SelectableFieldsGroup from './components/SelectableFieldsGroup'
+import SelectSection from './components/SelectSection'
+import SortableFieldsGroup from './components/SortableFieldsGroup'
+import SortedFieldsTitle from './components/SortedFieldsTitle'
+import { EXPORT_FORMATS } from './constants'
+import useExportStorage from './hooks/use-export-storage'
+import useSelectFields from './hooks/use-select-fields'
+import * as S from './styles'
+import updateSelectedStates from './utils/update-selected-states'
+
+type Props = ModalProps & Partial<LibraryExport>
+
+const exportStorage = storage<ExportStorage>(STORAGE_KEY.EXPORT)
+
+const ExportModal = ({ exportTarget, exportItems, opened, onClose, ...props }: Props) => {
+  const [selectedFields, setSelectedFields] = useState<ExportField[]>([])
+  const [sortedFields, sortedFieldsHandlers] = useListState<ExportField>([])
+  const [format, setFormat] = useState<ExportFormatKey>('csv')
+
+  const [isExporting, setIsExporting] = useState(false)
+
+  const { data, isLoading, error } = useFieldsCatalog({
+    enabled: opened,
+    onSuccess: values => {
+      // Update the selected & sorted fields after loading the catalog
+      updateSelectedStates({
+        storage: exportStorage,
+        exportFields: values.fields_catalog,
+        setSelectedFields,
+        setSortedFields: sortedFieldsHandlers.setState,
+        setFormat
+      })
+    }
+  })
+
+  const exportFields = data?.fields_catalog ?? []
+
+  const loading = isLoading || !data || !!error
+
+  const { saveExportOptions } = useExportStorage({
+    opened,
+    exportFields,
+    setSelectedFields,
+    setSortedFields: sortedFieldsHandlers.setState,
+    setFormat
+  })
+
+  const {
+    handleSelectFields,
+    handleSelectAllNone,
+    handleUnselect,
+    handleDragEnd,
+    handleResetOrder
+  } = useSelectFields({
+    allFields: exportFields,
+    selectedFields,
+    setSelectedFields,
+    sortedFields,
+    sortedFieldsHandlers
+  })
+
+  const [scrollPosition, setScrollPosition] = useState<Position>()
+
+  const selectedFormat = useMemo(
+    () => EXPORT_FORMATS.find(({ value }) => value === format),
+    [format]
+  )
+
+  if (!exportItems) {
+    return null
+  }
+
+  const areFieldsSelected = selectedFields.length > 0
+
+  const handleExport = async () => {
+    saveExportOptions(sortedFields, format)
+
+    setIsExporting(true)
+
+    const payload: ExportMetaPayload = {
+      // TODO: Use `_id` everywhere
+      ids: exportItems.map(({ documentId }) => documentId),
+      fields: sortedFields.map(({ name }) => name),
+      format
+    }
+
+    try {
+      await exportMeta(payload, exportTarget?.title)
+
+      notifications.showSuccess('Metadata exported successfully.')
+      onClose()
+    } catch (err) {
+      notifications.showError('Something went wrong exporting the metadata.', {
+        description: 'Please try again later.',
+        autoClose: true
+      })
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const availableFieldsTitle = (
+    <AvailableFieldsTitle
+      areFieldsSelected={areFieldsSelected}
+      loading={loading}
+      onSelectAllNone={handleSelectAllNone}
+    />
+  )
+
+  const sortedFieldsTitle = (
+    <SortedFieldsTitle
+      selectedFields={selectedFields}
+      sortedFields={sortedFields}
+      loading={loading}
+      onResetOrder={handleResetOrder}
+    />
+  )
+
+  const actions = (
+    <Group spacing="sm">
+      <CancelButton onClick={onClose} />
+
+      <Button
+        color="blue"
+        loading={isExporting}
+        disabled={loading || !areFieldsSelected}
+        onClick={handleExport}
+      >
+        Export {selectedFormat?.label}
+      </Button>
+    </Group>
+  )
+
+  return (
+    <DefaultModal
+      opened={opened}
+      title="Export metadata"
+      icon={<FiCornerUpRight />}
+      actions={actions}
+      onClose={onClose}
+      {...props}
+      css={S.root}
+    >
+      <div css={S.content}>
+        <div css={S.format}>
+          <ExportFormat data={EXPORT_FORMATS} value={format} onChange={setFormat} />
+        </div>
+
+        <SelectSection title={availableFieldsTitle} loading={loading}>
+          <SelectableFieldsGroup
+            fields={exportFields}
+            selected={selectedFields}
+            onSelect={handleSelectFields}
+          />
+        </SelectSection>
+
+        <SelectSection
+          title={sortedFieldsTitle}
+          loading={loading}
+          onScrollPositionChange={setScrollPosition}
+        >
+          <SortableFieldsGroup
+            fields={sortedFields}
+            scrollOffset={scrollPosition?.y}
+            onDragEnd={handleDragEnd}
+            onUnselect={handleUnselect}
+          />
+        </SelectSection>
+      </div>
+    </DefaultModal>
+  )
+}
+
+export default ExportModal

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/AvailableFieldsTitle/AvailableFieldsTitle.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/AvailableFieldsTitle/AvailableFieldsTitle.tsx
@@ -1,0 +1,32 @@
+import { IconArrowBigLeftLine, IconArrowBigRightLine } from '@tabler/icons-react'
+
+import ActionLink from '~/components/ActionLink'
+
+import SelectSectionTitle from '../SelectSectionTitle'
+
+type Props = {
+  areFieldsSelected: boolean
+  loading?: boolean
+  onSelectAllNone: () => void
+}
+
+const AvailableFieldsTitle = ({ areFieldsSelected, loading, onSelectAllNone }: Props) => {
+  const tooltip = loading ? undefined : 'Select the fields to include for each exported document'
+
+  const action = !loading && (
+    <ActionLink
+      leftIcon={areFieldsSelected ? <IconArrowBigLeftLine /> : <IconArrowBigRightLine />}
+      onClick={onSelectAllNone}
+    >
+      Select {areFieldsSelected ? 'none' : 'all'}
+    </ActionLink>
+  )
+
+  return (
+    <SelectSectionTitle title="Available fields" tooltip={tooltip}>
+      {action}
+    </SelectSectionTitle>
+  )
+}
+
+export default AvailableFieldsTitle

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/AvailableFieldsTitle/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/AvailableFieldsTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AvailableFieldsTitle'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/ExportFormat/ExportFormat.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/ExportFormat/ExportFormat.tsx
@@ -1,0 +1,40 @@
+import { Select, Stack } from '@mantine/core'
+
+import InfoTitle from '~/components/InfoTitle'
+
+import type { ExportFormatKey, ExportSelectItem } from '~/types/library/library-export'
+
+type Props = {
+  data: ExportSelectItem[]
+  value: ExportFormatKey
+  onChange: (value: ExportFormatKey) => void
+}
+
+const ExportFormat = ({ data, value, onChange }: Props) => {
+  const tooltipLabel = (
+    <Stack spacing="xs">
+      <div>Select the format for the exported data.</div>
+
+      <div>CSV is a simple text format that can be opened in any spreadsheet application.</div>
+
+      <div>
+        JSON is a structured format that can be used to import data into other applications.
+      </div>
+    </Stack>
+  )
+
+  return (
+    <Stack spacing="xs" align="center">
+      <InfoTitle
+        tooltip={tooltipLabel}
+        tooltipOptions={{ width: 400, multiline: true, withinPortal: true }}
+      >
+        Export format
+      </InfoTitle>
+
+      <Select data={data} value={value} onChange={onChange} />
+    </Stack>
+  )
+}
+
+export default ExportFormat

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/ExportFormat/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/ExportFormat/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExportFormat'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/FieldInfo/FieldInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/FieldInfo/FieldInfo.tsx
@@ -1,0 +1,24 @@
+import { Text } from '@mantine/core'
+
+import type { ClassNameProp } from '~/types/children-props'
+import type { ExportField } from '~/types/library/library-export'
+
+type Props = ClassNameProp & {
+  field: ExportField
+}
+
+const FieldInfo = ({ field: { name, description }, className }: Props) => {
+  return (
+    <div className={className}>
+      <Text size="md" mb={0}>
+        {name}
+      </Text>
+
+      <Text size="sm" color="dimmed">
+        {description}
+      </Text>
+    </div>
+  )
+}
+
+export default FieldInfo

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/FieldInfo/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/FieldInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FieldInfo'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/SelectSection.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/SelectSection.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Loader, ScrollArea, Text } from '@mantine/core'
+
+import type { Position } from '~/hooks/use-scrolled'
+import type { ChildrenProp } from '~/types/children-props'
+
+import * as S from './styles'
+
+const SCROLL_THRESHOLD = 12
+
+type Props = ChildrenProp & {
+  title: ReactNode
+  loading?: boolean
+  onScrollPositionChange?: (position: Position) => void
+}
+
+const SelectSection = ({ title, loading, children, onScrollPositionChange }: Props) => {
+  const [scrolled, setScrolled] = useState(false)
+
+  const handleScrollChange = (position: Position) => {
+    setScrolled(position.y > SCROLL_THRESHOLD)
+
+    onScrollPositionChange?.(position)
+  }
+
+  const content = loading ? (
+    <div css={S.loaderWrapper}>
+      <Loader color="gray" />
+    </div>
+  ) : (
+    <ScrollArea.Autosize css={S.scrollArea} onScrollPositionChange={handleScrollChange}>
+      <div css={S.content}>{children}</div>
+    </ScrollArea.Autosize>
+  )
+
+  return (
+    <div css={S.root} data-scrolled={scrolled}>
+      <Text size="md" className="title">
+        {title}
+      </Text>
+
+      {content}
+    </div>
+  )
+}
+
+export default SelectSection

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SelectSection'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSection/styles.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid ${theme.colors.gray[3]};
+  border-radius: ${theme.radius.md};
+  padding: 0;
+  background-color: ${theme.white};
+  overflow: hidden;
+
+  .title {
+    z-index: 1;
+    padding: ${theme.spacing.md} ${theme.spacing.lg};
+    border-bottom: 1px solid ${theme.colors.gray[2]};
+
+    will-change: box-shadow, border-color;
+    transition: box-shadow 0.2s ${theme.transitionTimingFunction},
+      border-color 0.2s ${theme.transitionTimingFunction};
+  }
+
+  [data-item] {
+    margin-bottom: ${theme.spacing.sm};
+  }
+
+  &[data-scrolled='true'] {
+    .title {
+      box-shadow: ${theme.shadows.sm};
+      border-bottom-color: ${theme.colors.gray[3]};
+    }
+  }
+`
+
+export const content: ThemedCSS = theme => css`
+  padding: ${theme.spacing.lg} ${theme.spacing.xl};
+  padding-bottom: calc(${theme.spacing.lg} - ${theme.spacing.sm});
+`
+
+export const loaderWrapper = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 0.8;
+`
+
+export const scrollArea = css`
+  flex-grow: 1;
+  min-height: 0;
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSectionTitle/SelectSectionTitle.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSectionTitle/SelectSectionTitle.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import { Flex } from '@mantine/core'
+
+import InfoTitle from '~/components/InfoTitle'
+
+type Props = {
+  title: ReactNode
+  tooltip?: ReactNode
+  children?: ReactNode
+}
+
+const SelectSectionTitle = ({ title, tooltip, children }: Props) => {
+  return (
+    <Flex justify="space-between" align="center">
+      <InfoTitle tooltip={tooltip}>{title}</InfoTitle>
+
+      {children}
+    </Flex>
+  )
+}
+
+export default SelectSectionTitle

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSectionTitle/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectSectionTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SelectSectionTitle'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/SelectableField.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/SelectableField.tsx
@@ -1,0 +1,28 @@
+import { IconArrowRight } from '@tabler/icons-react'
+
+import type { ExportField } from '~/types/library/library-export'
+
+import * as S from './styles'
+
+import FieldInfo from '../FieldInfo'
+
+type Props = {
+  field: ExportField
+  selected?: boolean
+  onChange?: (selected: boolean) => void
+}
+
+const SelectableField = ({ field, selected, onChange }: Props) => {
+  const handleClick = () => {
+    onChange?.(!selected)
+  }
+
+  return (
+    <div css={S.root} role="checkbox" aria-checked={selected} onClick={handleClick}>
+      <FieldInfo field={field} />
+      <IconArrowRight css={S.rightIcon} data-icon />
+    </div>
+  )
+}
+
+export default SelectableField

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SelectableField'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableField/styles.ts
@@ -1,0 +1,52 @@
+import { css } from '@emotion/react'
+
+export const root: ThemedCSS = theme => css`
+  display: grid;
+  grid-template-columns: 1fr 24px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 8px ${theme.spacing.md};
+  padding-right: ${theme.spacing.sm};
+  border-radius: ${theme.radius.sm};
+  overflow: hidden;
+  margin-bottom: ${theme.spacing.sm};
+  cursor: pointer;
+  max-height: 200px;
+
+  transition: max-height 0.2s ${theme.transitionTimingFunction},
+    padding 0.2s ${theme.transitionTimingFunction}, margin 0.2s ${theme.transitionTimingFunction},
+    opacity 0.2s ${theme.transitionTimingFunction};
+
+  [data-icon] {
+    display: none;
+  }
+
+  &:hover {
+    background-color: ${theme.colors.gray[1]};
+
+    [data-icon] {
+      display: block;
+    }
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &[aria-checked='true'] {
+    transition: all 0.2s ${theme.transitionTimingFunction};
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    transform: translateX(1rem);
+  }
+`
+
+export const rightIcon: ThemedCSS = theme => css`
+  color: ${theme.colors.blue[4]};
+  flex-shrink: 0;
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableFieldsGroup/SelectableFieldsGroup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableFieldsGroup/SelectableFieldsGroup.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react'
+import { Stack, Text } from '@mantine/core'
+
+import type { ExportField } from '~/types/library/library-export'
+
+import SelectableField from '../SelectableField'
+
+type Props = {
+  fields: ExportField[]
+  selected: ExportField[]
+  onSelect: (selected: ExportField[]) => void
+}
+
+const SelectableFieldsGroup = ({ fields, selected, onSelect }: Props) => {
+  const selectedValues = useMemo(() => selected.map(({ name }) => name), [selected])
+
+  const allSelected = fields.length === selected.length
+
+  const handleItemChange = (field: ExportField, value: boolean) => {
+    const newSelected = value
+      ? [...selected, field]
+      : selected.filter(({ name }) => name !== field.name)
+
+    onSelect(newSelected)
+  }
+
+  return (
+    <div>
+      {fields.map(field => (
+        <SelectableField
+          key={field.name}
+          field={field}
+          selected={selectedValues.includes(field.name)}
+          onChange={value => handleItemChange(field, value)}
+        />
+      ))}
+
+      {allSelected && (
+        <Stack spacing="xs" align="center" mt="md">
+          <Text>No more fields to show here.</Text>
+
+          <Text size="sm" color="dimmed">
+            All the available fields are selected for export.
+          </Text>
+        </Stack>
+      )}
+    </div>
+  )
+}
+
+export default SelectableFieldsGroup

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableFieldsGroup/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SelectableFieldsGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SelectableFieldsGroup'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/SortableFieldsGroup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/SortableFieldsGroup.tsx
@@ -1,0 +1,125 @@
+import { useRef, type CSSProperties } from 'react'
+import type {
+  DraggableProvided,
+  DraggableStateSnapshot,
+  OnDragEndResponder
+} from '@hello-pangea/dnd'
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
+import { ActionIcon, Stack, Text } from '@mantine/core'
+import { IconGripVertical, IconX } from '@tabler/icons-react'
+
+import FieldInfo from '~/pages/SearchPageNew/components/documents/ExportModal/components/FieldInfo'
+
+import type { ExportField } from '~/types/library/library-export'
+
+import * as S from './styles'
+
+// Disable the nested scroll containers warning,
+// we're handling the scroll offset manually.
+window['__@hello-pangea/dnd-disable-dev-warnings'] = true
+
+type Props = {
+  fields: ExportField[] | undefined
+  scrollOffset?: number
+  onDragEnd: OnDragEndResponder
+  onUnselect?: (field: ExportField) => void
+}
+
+const getItemStyle = (
+  provided: DraggableProvided,
+  snapshot: DraggableStateSnapshot,
+  scrollOffset = 0
+): CSSProperties | undefined => {
+  const { isDragging } = snapshot
+  const { style } = provided.draggableProps
+  const { transform, ...rest } = style ?? {}
+
+  // Get the vertical translate value
+  const verticalTransform = transform?.match(/translate\(.*?,(.*?)px\)/)?.[1]
+
+  // If the item is being dragged, subtract the scroll offset from the vertical translate value
+  const offsetValue = isDragging
+    ? verticalTransform
+      ? +verticalTransform - scrollOffset
+      : undefined
+    : verticalTransform
+
+  return {
+    ...rest,
+    // Lock the horizontal translation to 0
+    transform: offsetValue ? `translate(0, ${offsetValue}px)` : undefined
+  }
+}
+
+const SortableFieldsGroup = ({ fields = [], scrollOffset, onDragEnd, onUnselect }: Props) => {
+  // Freeze the scroll offset value while dragging
+  const frozenScrollOffsetRef = useRef<number | undefined>()
+
+  const handleDragStart = () => {
+    frozenScrollOffsetRef.current = scrollOffset
+  }
+
+  const handleDragEnd: OnDragEndResponder = (result, provided) => {
+    frozenScrollOffsetRef.current = undefined
+
+    const { source, destination } = result
+
+    if (!destination || destination.index === source.index) {
+      return
+    }
+
+    onDragEnd(result, provided)
+  }
+
+  if (!fields.length) {
+    return (
+      <Stack align="center" spacing="xs" mt="lg">
+        <Text>No fields selected for export.</Text>
+
+        <Text size="sm" color="dimmed">
+          Select from the available fields on the left.
+        </Text>
+      </Stack>
+    )
+  }
+
+  const items = fields.map((field, index) => (
+    <Draggable key={field.name} index={index} draggableId={field.name}>
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          css={[S.item, snapshot.isDragging && S.itemDragging]}
+          {...provided.draggableProps}
+          style={getItemStyle(provided, snapshot, frozenScrollOffsetRef.current)}
+          data-item
+        >
+          <div css={S.dragHandle} {...provided.dragHandleProps}>
+            <IconGripVertical size={18} stroke={1.5} />
+          </div>
+
+          <FieldInfo field={field} css={S.fieldInfo} />
+
+          <ActionIcon ml="xs" onClick={() => onUnselect?.(field)}>
+            <IconX size={18} />
+          </ActionIcon>
+        </div>
+      )}
+    </Draggable>
+  ))
+
+  return (
+    <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <Droppable droppableId="drop-list" direction="vertical">
+        {provided => (
+          <div {...provided.droppableProps} ref={provided.innerRef}>
+            {items}
+
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  )
+}
+
+export default SortableFieldsGroup

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SortableFieldsGroup'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortableFieldsGroup/styles.ts
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react'
+
+export const item: ThemedCSS = theme => css`
+  display: flex;
+  align-items: center;
+  border-radius: ${theme.radius.md};
+  border: 1px solid ${theme.colors.gray[3]};
+  padding: 8px ${theme.spacing.sm};
+  padding-left: 0;
+  margin-bottom: ${theme.spacing.sm};
+  background: ${theme.white};
+  transition: background-color 0.2s ${theme.transitionTimingFunction},
+    border-color 0.2s ${theme.transitionTimingFunction};
+  left: auto !important;
+  top: auto !important;
+`
+
+export const itemDragging: ThemedCSS = theme => css`
+  background-color: ${theme.colors.gray[0]};
+  border-color: ${theme.colors.gray[4]};
+`
+
+export const dragHandle: ThemedCSS = theme => css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: ${theme.colors.gray[5]};
+  padding: 0 ${theme.spacing.sm};
+  cursor: grab;
+`
+
+export const fieldInfo = css`
+  flex: 1;
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortedFieldsTitle/SortedFieldsTitle.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortedFieldsTitle/SortedFieldsTitle.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { IconArrowBackUp } from '@tabler/icons-react'
+
+import ActionLink from '~/components/ActionLink'
+
+import type { ExportField } from '~/types/library/library-export'
+
+import SelectSectionTitle from '../SelectSectionTitle'
+
+type Props = {
+  selectedFields: ExportField[]
+  sortedFields: ExportField[]
+  loading?: boolean
+  onResetOrder: () => void
+}
+
+const SortedFieldsTitle = ({ selectedFields, sortedFields, loading, onResetOrder }: Props) => {
+  const areFieldsSelected = selectedFields.length > 0
+
+  const isOrderChanged = useMemo(
+    () =>
+      sortedFields.length > 0 &&
+      sortedFields.map(({ name }) => name).join() !== selectedFields.map(({ name }) => name).join(),
+    [selectedFields, sortedFields]
+  )
+
+  const tooltip =
+    loading || !areFieldsSelected
+      ? undefined
+      : 'Drag and drop to set the order of the exported fields'
+
+  return (
+    <SelectSectionTitle title="Fields to export" tooltip={tooltip}>
+      {isOrderChanged && (
+        <ActionLink leftIcon={<IconArrowBackUp />} onClick={onResetOrder}>
+          Reset order
+        </ActionLink>
+      )}
+    </SelectSectionTitle>
+  )
+}
+
+export default SortedFieldsTitle

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortedFieldsTitle/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/components/SortedFieldsTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SortedFieldsTitle'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/constants.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/constants.ts
@@ -1,0 +1,13 @@
+import { ExportMimeType } from '~/types/library/library-export'
+import type { ExportSelectItem } from '~/types/library/library-export'
+
+export const EXPORT_FORMATS: ExportSelectItem[] = [
+  {
+    value: 'csv',
+    label: ExportMimeType.csv.name
+  },
+  {
+    value: 'json',
+    label: ExportMimeType.json.name
+  }
+]

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-export-storage.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-export-storage.ts
@@ -1,0 +1,66 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { useEffect } from 'react'
+
+import updateSelectedStates from '~/pages/SearchPageNew/components/documents/ExportModal/utils/update-selected-states'
+import { STORAGE_KEY } from '~/pages/SearchPageNew/utils/constants'
+
+import type { ExportField, ExportFormatKey, ExportStorage } from '~/types/library/library-export'
+import { storage } from '~/utils/storage-utils'
+
+const exportStorage = storage<ExportStorage>(STORAGE_KEY.EXPORT)
+
+type Args = {
+  opened: boolean
+  exportFields: ExportField[]
+  setSelectedFields: Dispatch<SetStateAction<ExportField[]>>
+  setSortedFields: Dispatch<SetStateAction<ExportField[]>>
+  setFormat: Dispatch<SetStateAction<ExportFormatKey>>
+}
+
+const useExportStorage = ({
+  opened,
+  exportFields,
+  setSelectedFields,
+  setSortedFields,
+  setFormat
+}: Args) => {
+  useEffect(() => {
+    updateStates()
+    // We only want to run this effect once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (opened) {
+      return
+    }
+
+    // Wait for the modal to close before updating the states
+    setTimeout(() => {
+      updateStates()
+    }, 300)
+
+    // We only want to run this effect when `opened` changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened])
+
+  const updateStates = () => {
+    updateSelectedStates({
+      storage: exportStorage,
+      exportFields,
+      setSelectedFields,
+      setSortedFields,
+      setFormat
+    })
+  }
+
+  const saveExportOptions = (sortedFields: ExportField[], format: ExportFormatKey) => {
+    const fieldsNames = sortedFields.map(field => field.name)
+
+    exportStorage.write({ fieldsNames, format })
+  }
+
+  return { saveExportOptions }
+}
+
+export default useExportStorage

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-select-fields.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-select-fields.ts
@@ -1,0 +1,71 @@
+import type { Dispatch, SetStateAction } from 'react'
+import type { OnDragEndResponder } from '@hello-pangea/dnd'
+import type { UseListStateHandlers } from '@mantine/hooks'
+
+import type { ExportField } from '~/types/library/library-export'
+
+type Args = {
+  allFields: ExportField[]
+  selectedFields: ExportField[]
+  setSelectedFields: Dispatch<SetStateAction<ExportField[]>>
+  sortedFields: ExportField[]
+  sortedFieldsHandlers: UseListStateHandlers<ExportField>
+}
+
+const useSelectFields = ({
+  allFields,
+  selectedFields,
+  setSelectedFields,
+  sortedFields,
+  sortedFieldsHandlers
+}: Args) => {
+  const areFieldsSelected = selectedFields.length > 0
+
+  const handleSelectFields = (fields: ExportField[]) => {
+    setSelectedFields(fields)
+
+    // Add new fields to the end of the list to preserve the order of the already sorted fields
+    // Remove fields that are not selected anymore
+
+    const toAdd = fields.filter(field => !sortedFields.includes(field))
+    const toRemove = sortedFields.filter(field => !fields.includes(field))
+
+    sortedFieldsHandlers.setState(
+      [...sortedFields, ...toAdd].filter(field => !toRemove.includes(field))
+    )
+  }
+
+  const handleDragEnd: OnDragEndResponder = ({ source, destination }) => {
+    sortedFieldsHandlers.reorder({ from: source.index, to: destination?.index ?? 0 })
+  }
+
+  const handleUnselect = (field: ExportField) => {
+    const selectedFieldsNew = selectedFields.filter(({ name }) => name !== field.name)
+
+    const sortedFieldsNew = sortedFields.filter(({ name }) => name !== field.name)
+
+    setSelectedFields(selectedFieldsNew)
+    sortedFieldsHandlers.setState(sortedFieldsNew)
+  }
+
+  const handleSelectAllNone = () => {
+    const fields: ExportField[] = areFieldsSelected ? [] : allFields
+
+    setSelectedFields(fields)
+    sortedFieldsHandlers.setState(fields)
+  }
+
+  const handleResetOrder = () => {
+    sortedFieldsHandlers.setState(selectedFields)
+  }
+
+  return {
+    handleSelectFields,
+    handleSelectAllNone,
+    handleUnselect,
+    handleResetOrder,
+    handleDragEnd
+  }
+}
+
+export default useSelectFields

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/index.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExportModal'

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react'
+
+export const root = css`
+  .seta-Paper-root {
+    flex-basis: 60rem;
+  }
+`
+
+export const content = css`
+  height: 50vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 2rem;
+  padding: 0.5rem 0.5rem;
+`
+
+export const format = css`
+  grid-column: span 2;
+`

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/utils/update-selected-states.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/utils/update-selected-states.ts
@@ -1,0 +1,48 @@
+import type { Dispatch, SetStateAction } from 'react'
+
+import type { ExportField, ExportFormatKey, ExportStorage } from '~/types/library/library-export'
+import type { StorageOperations } from '~/utils/storage-utils'
+
+type Args = {
+  storage: StorageOperations<ExportStorage>
+  exportFields: ExportField[]
+  setSelectedFields: Dispatch<SetStateAction<ExportField[]>>
+  setSortedFields: Dispatch<SetStateAction<ExportField[]>>
+  setFormat: Dispatch<SetStateAction<ExportFormatKey>>
+}
+
+const updateSelectedStates = ({
+  storage,
+  exportFields,
+  setSelectedFields,
+  setSortedFields,
+  setFormat
+}: Args) => {
+  const storageValue = storage.read()
+
+  if (!storageValue) {
+    setSelectedFields([])
+    setSortedFields([])
+
+    return
+  }
+
+  const { fieldsNames, format } = storageValue
+
+  // Use the export fields that are in the storage, ignore those that are not available anymore
+  const filteredFields = fieldsNames.reduce<ExportField[]>((acc, name) => {
+    const field = exportFields.find(f => f.name === name)
+
+    if (field) {
+      acc.push(field)
+    }
+
+    return acc
+  }, [])
+
+  setSelectedFields(filteredFields)
+  setSortedFields(filteredFields)
+  setFormat(format)
+}
+
+export default updateSelectedStates

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryNode.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/LibraryNode.tsx
@@ -140,8 +140,10 @@ const LibraryNode = ({ className, item, isRoot }: Props) => {
     </Badge>
   )
 
+  const nodeStyle = [S.node, isFolder && !foldersOnly && isExpanded && S.expanded]
+
   return (
-    <div css={S.node} className={className}>
+    <div css={nodeStyle} className={className} data-root={isRoot ? true : undefined} data-node>
       <Tooltip
         label={path.join(' / ')}
         openDelay={1000}

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/OptionsMenuAction/OptionsMenuAction.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/OptionsMenuAction/OptionsMenuAction.tsx
@@ -19,7 +19,7 @@ type Props = {
 const OptionsMenuAction = ({ item, isLoading, onMenuChange }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const { renameFolder, confirmDelete, moveItem } = useTreeActions()
+  const { renameFolder, confirmDelete, moveItem, exportItem } = useTreeActions()
 
   const isFolder = item.type === LibraryItemType.Folder
   const subject = isFolder ? 'folder' : 'document'
@@ -58,7 +58,9 @@ const OptionsMenuAction = ({ item, isLoading, onMenuChange }: Props) => {
 
       <Menu.Divider />
 
-      <Menu.Item icon={<FiCornerUpRight />}>Export {isFolder ? 'documents' : 'document'}</Menu.Item>
+      <Menu.Item icon={<FiCornerUpRight />} onClick={() => exportItem(item)}>
+        Export metadata
+      </Menu.Item>
     </ActionIconMenu>
   )
 }

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/tree-actions-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/tree-actions-context.tsx
@@ -4,6 +4,7 @@ import type { ChildrenProp } from '~/types/children-props'
 import type { LibraryItem } from '~/types/library/library-item'
 
 import useDeleteModal from '../hooks/use-delete-modal'
+import useExportModal from '../hooks/use-export-modal'
 import useMoveModal from '../hooks/use-move-modal'
 import useRenameModal from '../hooks/use-rename-modal'
 
@@ -11,6 +12,7 @@ type TreeActionsContextProps = {
   renameFolder: (folder: LibraryItem) => void
   confirmDelete: (item: LibraryItem) => void
   moveItem: (item: LibraryItem) => void
+  exportItem: (item: LibraryItem) => void
 }
 
 const TreeActionsContext = createContext<TreeActionsContextProps | undefined>(undefined)
@@ -19,11 +21,13 @@ const TreeActionsProvider = ({ children }: ChildrenProp) => {
   const { renameFolder, renameModal } = useRenameModal()
   const { confirmDelete, confirmDeleteModal } = useDeleteModal()
   const { moveItem, moveModal } = useMoveModal()
+  const { exportItem, exportModal } = useExportModal()
 
   const value: TreeActionsContextProps = {
     renameFolder,
     confirmDelete,
-    moveItem
+    moveItem,
+    exportItem
   }
 
   return (
@@ -33,6 +37,7 @@ const TreeActionsProvider = ({ children }: ChildrenProp) => {
       {renameModal}
       {confirmDeleteModal}
       {moveModal}
+      {exportModal}
     </>
   )
 }

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-export-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-export-modal.tsx
@@ -1,0 +1,28 @@
+import ExportModal from '~/pages/SearchPageNew/components/documents/ExportModal'
+
+import useComplexModalState from '~/hooks/use-complex-modal-state'
+import type { LibraryExport } from '~/types/library/library-export'
+import type { LibraryItem } from '~/types/library/library-item'
+import { getDocumentsForExport } from '~/utils/library-utils'
+
+const useExportModal = () => {
+  const { open, openModal, closeModal, modalState } = useComplexModalState<LibraryExport>()
+
+  const exportItem = (target: LibraryItem) => {
+    const exportItems = getDocumentsForExport(target)
+
+    openModal({
+      exportTarget: target,
+      exportItems
+    })
+  }
+
+  const exportModal = <ExportModal opened={open} {...modalState} onClose={closeModal} />
+
+  return {
+    exportItem,
+    exportModal
+  }
+}
+
+export default useExportModal

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/styles.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/styles.ts
@@ -10,6 +10,24 @@ export const rootNode = css`
 export const node: ThemedCSS = theme => css`
   margin-left: ${theme.spacing.sm};
   white-space: nowrap;
+  position: relative;
+`
+
+export const expanded: ThemedCSS = theme => css`
+  &:not([data-root])::before {
+    content: '';
+    position: absolute;
+    left: 1px;
+    top: 3.3rem;
+    bottom: 0.2rem;
+    width: 1px;
+    background-color: ${theme.colors.gray[3]};
+    transition: background-color 200ms ease;
+  }
+
+  & [data-node]:hover::before {
+    background-color: ${theme.colors.blue[3]};
+  }
 `
 
 export const itemContainer: ThemedCSS = theme => css`

--- a/seta-react/src/pages/SearchPageNew/utils/constants.ts
+++ b/seta-react/src/pages/SearchPageNew/utils/constants.ts
@@ -2,5 +2,6 @@ export const STORAGE_KEY = {
   SEARCH: 'seta-search-value',
   ENRICH: 'seta-search-enrich',
   UPLOADS: 'seta-search-uploads',
-  STAGED_DOCS: 'seta-search-staged-docs'
+  STAGED_DOCS: 'seta-search-staged-docs',
+  EXPORT: 'seta-library-export'
 }

--- a/seta-react/src/types/library/library-export.ts
+++ b/seta-react/src/types/library/library-export.ts
@@ -1,0 +1,45 @@
+import type { LibraryItem } from '~/types/library/library-item'
+
+export type LibraryItemExport = {
+  documentId: string
+  paths: string[]
+}
+
+export type ExportField = {
+  name: string
+  description: string
+}
+
+export type LibraryExport = {
+  exportTarget: LibraryItem
+  exportItems: LibraryItemExport[]
+}
+
+export type ExportFormatKey = 'csv' | 'json'
+
+export const ExportMimeType: Record<
+  ExportFormatKey,
+  {
+    name: string
+    mimeType: string
+  }
+> = {
+  csv: {
+    name: 'CSV',
+    mimeType: 'text/csv'
+  },
+  json: {
+    name: 'JSON',
+    mimeType: 'application/json'
+  }
+} as const
+
+export type ExportSelectItem = {
+  value: ExportFormatKey
+  label: string
+}
+
+export type ExportStorage = {
+  fieldsNames: string[]
+  format: ExportFormatKey
+}

--- a/seta-react/src/utils/date-utils.ts
+++ b/seta-react/src/utils/date-utils.ts
@@ -3,3 +3,8 @@ export const dateFormatted = (date: string) => {
 
   return new Date(date).toLocaleDateString('en-GB', options)
 }
+
+/**
+ * Returns a timestamp in the format YYYYMMDDHHmmss
+ */
+export const getTimestamp = () => new Date().toISOString().replace(/(\..*$)|[-T:Z]/g, '')

--- a/seta-react/src/utils/file-utils.ts
+++ b/seta-react/src/utils/file-utils.ts
@@ -1,0 +1,19 @@
+export const downloadFile = (data: Blob, fileName: string) => {
+  // Create a temporary URL to the download blob
+  const href = URL.createObjectURL(data)
+
+  // Create a temporary link element to trigger the download
+  const link = document.createElement('a')
+
+  link.href = href
+  link.setAttribute('download', fileName)
+
+  link.dataset.downloadurl = [data.type, link.download, link.href].join(':')
+
+  document.body.appendChild(link)
+  link.click()
+
+  // Clean up
+  document.body.removeChild(link)
+  URL.revokeObjectURL(href)
+}

--- a/seta-react/src/utils/library-utils.ts
+++ b/seta-react/src/utils/library-utils.ts
@@ -1,1 +1,38 @@
+import type { LibraryItemExport } from '~/types/library/library-export'
+import { LibraryItemType, type LibraryItem } from '~/types/library/library-item'
+
 export const ROOT_LIBRARY_ITEM_NAME = 'My Library'
+
+export const getDocumentsForExport = (libraryItem: LibraryItem): LibraryItemExport[] => {
+  const dict: Map<string, LibraryItemExport> = new Map()
+
+  const traverse = (item: LibraryItem): void => {
+    if (item.type === LibraryItemType.Document) {
+      const { documentId, path } = item
+
+      if (documentId) {
+        const value: LibraryItemExport = dict.get(documentId) ?? {
+          documentId,
+          paths: []
+        }
+
+        // Remove the last item from the path, which is the document name
+        const formattedPath = path.slice(0, -1).join(' / ')
+
+        if (!value.paths.includes(formattedPath)) {
+          value.paths.push(formattedPath)
+        }
+
+        dict.set(documentId, value)
+      }
+    } else {
+      item.children.forEach(child => {
+        traverse(child)
+      })
+    }
+  }
+
+  traverse(libraryItem)
+
+  return Array.from(dict.values())
+}

--- a/seta-react/src/utils/notifications/styles.ts
+++ b/seta-react/src/utils/notifications/styles.ts
@@ -10,6 +10,8 @@ export const getStyles = (type: NotificationType): NotificationProps['styles'] =
 
   return theme => ({
     root: {
+      borderWidth: 1,
+      borderStyle: 'solid',
       borderColor: theme.colors[color][6],
       backgroundColor: theme.colors[color][0],
       boxShadow: '3px 3px 6px 0px rgba(0,0,0, 0.2)',

--- a/seta-react/src/utils/storage-utils.ts
+++ b/seta-react/src/utils/storage-utils.ts
@@ -1,6 +1,12 @@
 import { deserializeJSON, serializeJSON } from '~/utils/json-utils'
 
-export const storage = <T>(key: string, initialValue?: T) => {
+export type StorageOperations<T> = {
+  read: () => T | null
+  write: (data: T) => T
+  remove: (reset?: boolean) => void
+}
+
+export const storage = <T>(key: string, initialValue?: T): StorageOperations<T> => {
   const read = (): T | null => {
     const data = localStorage.getItem(key)
 

--- a/seta-react/src/utils/string-utils.ts
+++ b/seta-react/src/utils/string-utils.ts
@@ -19,3 +19,14 @@ export const pluralize = (word: string, count: number, plural?: string): string 
 
   return count === 1 ? word : pluralWord
 }
+
+/**
+ * Converts a string to kebab-case
+ * @param text The text to convert
+ * @returns The converted text
+ */
+export const toKebabCase = (text: string): string =>
+  text
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s:;,.]+/g, '-')
+    .toLowerCase()


### PR DESCRIPTION
This PR implements the folder & file metadata export functionality for the Library.

Please note that the documents in the Library & Staged Documents still use `documentId` as identifiers and this will be corrected in a future PR - to keep the scope here a bit lower.

Also, exporting form the Staged Documents list will be implemented separately.