### PR TITLE
[seta-react] Use _id for Library docs & add Staged Docs export

### DIFF
--- a/seta-react/src/api/search/export.ts
+++ b/seta-react/src/api/search/export.ts
@@ -49,6 +49,8 @@ export const useFieldsCatalog = (args?: UseFieldsCatalogArgs) => {
     queryKey: fieldsCatalogQueryKey,
     queryFn: getFieldsCatalog,
     enabled,
+    // Disable stale time to always fetch the latest data
+    staleTime: 0,
     ...rest
   })
 }

--- a/seta-react/src/api/search/library.ts
+++ b/seta-react/src/api/search/library.ts
@@ -26,6 +26,7 @@ export type ItemsResponse = LibraryItem[]
 export type SaveDocumentsPayload = {
   parentId: string | null
   documents: {
+    // Using the `_id` field here
     documentId: string
     title: string
     link?: string | null

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
@@ -23,6 +23,7 @@ type Props = {
 
 const DocumentInfo = ({ document, queryTerms }: Props) => {
   const {
+    _id,
     document_id,
     title,
     score,
@@ -46,7 +47,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
     [source, collection, date]
   )
 
-  const isDocumentStaged = useMemo(() => isStaged(document_id), [document_id, isStaged])
+  const isDocumentStaged = useMemo(() => isStaged(_id), [_id, isStaged])
 
   const [titleHl, abstractHl] = useHighlight(queryTerms, title, abstract)
 
@@ -64,7 +65,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
       icon: <IconWallet size={22} />,
       color: 'orange',
       tooltip: 'Save to my documents',
-      onClick: () => handleSave([{ id: document_id, title, link: link_origin }])
+      onClick: () => handleSave([{ id: _id, title, link: link_origin }])
     },
     {
       name: 'stage-doc',
@@ -76,7 +77,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
       toggledColor: 'teal',
       toggledTooltip: 'Remove from staged documents',
       toggledIcon: <FiCheck size={22} style={{ marginTop: 2 }} />,
-      onToggle: staged => toggleStaged(document_id, title, link_origin, staged)
+      onToggle: staged => toggleStaged(_id, title, link_origin, staged)
     }
   ]
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/tree-actions-context.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/contexts/tree-actions-context.tsx
@@ -21,7 +21,7 @@ const TreeActionsProvider = ({ children }: ChildrenProp) => {
   const { renameFolder, renameModal } = useRenameModal()
   const { confirmDelete, confirmDeleteModal } = useDeleteModal()
   const { moveItem, moveModal } = useMoveModal()
-  const { exportItem, exportModal } = useExportModal()
+  const { exportLibraryItem: exportItem, exportModal } = useExportModal()
 
   const value: TreeActionsContextProps = {
     renameFolder,

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-export-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-export-modal.tsx
@@ -1,26 +1,45 @@
 import ExportModal from '~/pages/SearchPageNew/components/documents/ExportModal'
+import type { StagedDocument } from '~/pages/SearchPageNew/types/search'
 
 import useComplexModalState from '~/hooks/use-complex-modal-state'
-import type { LibraryExport } from '~/types/library/library-export'
-import type { LibraryItem } from '~/types/library/library-item'
+import type { LibraryExport, LibraryItemExport } from '~/types/library/library-export'
+import { LibraryItemType, type LibraryItem } from '~/types/library/library-item'
 import { getDocumentsForExport } from '~/utils/library-utils'
 
-const useExportModal = () => {
+type Args = {
+  withinPortal?: boolean
+}
+
+const useExportModal = (args?: Args) => {
+  const { withinPortal = true } = args ?? {}
+
   const { open, openModal, closeModal, modalState } = useComplexModalState<LibraryExport>()
 
-  const exportItem = (target: LibraryItem) => {
+  const exportLibraryItem = (target: LibraryItem) => {
     const exportItems = getDocumentsForExport(target)
 
-    openModal({
-      exportTarget: target,
-      exportItems
-    })
+    // If the target is a folder, use its title as the reference, otherwise leave it undefined
+    const reference = target.type === LibraryItemType.Folder ? target.title : undefined
+
+    openModal({ reference, exportItems })
   }
 
-  const exportModal = <ExportModal opened={open} {...modalState} onClose={closeModal} />
+  const exportStagedDocs = (docs: StagedDocument[]) => {
+    const exportItems: LibraryItemExport[] = docs.map(({ id }) => ({ documentId: id, paths: [] }))
+
+    // If there's only one document, use its title as the reference, otherwise leave it undefined
+    const reference = docs.length === 1 ? docs[0].title : undefined
+
+    openModal({ reference, exportItems })
+  }
+
+  const exportModal = (
+    <ExportModal withinPortal={withinPortal} opened={open} {...modalState} onClose={closeModal} />
+  )
 
   return {
-    exportItem,
+    exportLibraryItem,
+    exportStagedDocs,
     exportModal
   }
 }

--- a/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/StagedDocsPopup.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/StagedDocsPopup/StagedDocsPopup.tsx
@@ -3,6 +3,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { ScrollArea, Stack } from '@mantine/core'
 
 import PopupOverlay from '~/components/PopupOverlay'
+import useExportModal from '~/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-export-modal'
 import { useStagedDocuments } from '~/pages/SearchPageNew/contexts/staged-documents-context'
 import useSaveDocsModal from '~/pages/SearchPageNew/hooks/use-save-docs-modal'
 
@@ -49,6 +50,8 @@ const StagedDocsPopup = ({ target, open, onOpenChange }: Props) => {
     clearSelectedDocs,
     removeStaged
   })
+
+  const { exportStagedDocs, exportModal } = useExportModal({ withinPortal: false })
 
   const [animateRef] = useAutoAnimate<HTMLDivElement>({ duration: 200 })
 
@@ -100,6 +103,8 @@ const StagedDocsPopup = ({ target, open, onOpenChange }: Props) => {
             onRemoveAll={handleRemoveAll}
             onRemoveSelected={handleRemoveSelected}
             onSaveSelected={handleSave}
+            onExportSelected={() => exportStagedDocs(selectedDocs)}
+            onExportAll={() => exportStagedDocs(stagedDocuments)}
           />
 
           {documents}
@@ -107,6 +112,7 @@ const StagedDocsPopup = ({ target, open, onOpenChange }: Props) => {
 
         {confirmRemoveModal}
         {saveModal}
+        {exportModal}
       </PopupOverlay>
     </>
   )

--- a/seta-react/src/types/library/library-export.ts
+++ b/seta-react/src/types/library/library-export.ts
@@ -1,7 +1,6 @@
-import type { LibraryItem } from '~/types/library/library-item'
-
 export type LibraryItemExport = {
   documentId: string
+  // TODO: Export `path` as well
   paths: string[]
 }
 
@@ -11,7 +10,8 @@ export type ExportField = {
 }
 
 export type LibraryExport = {
-  exportTarget: LibraryItem
+  // The optional value to include in the name of the exported file
+  reference?: string
   exportItems: LibraryItemExport[]
 }
 

--- a/seta-react/src/utils/string-utils.ts
+++ b/seta-react/src/utils/string-utils.ts
@@ -25,8 +25,9 @@ export const pluralize = (word: string, count: number, plural?: string): string 
  * @param text The text to convert
  * @returns The converted text
  */
-export const toKebabCase = (text: string): string =>
+export const toKebabCase = (text: string, maxLength = 50): string =>
   text
+    .slice(0, maxLength)
     .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/[\s:;,.]+/g, '-')
+    .replace(/[\s:;,.-]+/g, '-')
     .toLowerCase()


### PR DESCRIPTION
This PR: 
- Changes the document identifier used in the Library and Staged Document to `_id`
- Adds support for exporting metadata from the Staged Documents popover