### PR TITLE
[seta-react] Revert search query cache options

### DIFF
--- a/seta-react/src/api/search/documents.ts
+++ b/seta-react/src/api/search/documents.ts
@@ -118,13 +118,6 @@ export const useDocuments = (
         { signal }
       ),
 
-    staleTime: Infinity,
-    cacheTime: 0,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    retry: false,
-
     ...options
   })
 }


### PR DESCRIPTION
This PR reverts the modifications previously done to the Search query cache options as I have identified some scenarios we need to discuss first.