### PR TITLE
[seta-react] Keep existing data on Search error

### DIFF
--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
@@ -6,6 +6,7 @@ import type { DocumentsOptions, DocumentsResponse } from '~/api/search/documents
 import { useDocuments } from '~/api/search/documents'
 import usePaginator from '~/hooks/use-paginator'
 import type { EmbeddingInfo } from '~/types/embeddings'
+import { notifications } from '~/utils/notifications'
 
 import DocumentsListContent from './DocumentsListContent'
 
@@ -21,6 +22,7 @@ type Props = {
 
 const DocumentsList = ({ query, terms, embeddings, searchOptions, onDocumentsChanged }: Props) => {
   const documentsChangedRef = useRef(onDocumentsChanged)
+  const errorNotificationShownRef = useRef(false)
 
   const [page, setPage] = useState(1)
 
@@ -31,6 +33,20 @@ const DocumentsList = ({ query, terms, embeddings, searchOptions, onDocumentsCha
     perPage: PER_PAGE,
     searchOptions
   })
+
+  // Show an error notification if there was an error fetching the documents
+  // and there is data (i.e. there was a successful request before)
+  if (error && data && !errorNotificationShownRef.current) {
+    errorNotificationShownRef.current = true
+
+    notifications.showError('There was an error refreshing the documents.', {
+      description: 'Please try again later.',
+      onClose: () => {
+        // Prevent showing the notification again until it's closed
+        errorNotificationShownRef.current = false
+      }
+    })
+  }
 
   useEffect(() => {
     if (data) {

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsListContent.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsListContent.tsx
@@ -20,7 +20,9 @@ type Props = DataProps<DocumentsResponse> & {
 
 const DocumentsListContent = forwardRef<HTMLDivElement, Props>(
   ({ data, isLoading, error, onTryAgain, queryTerms, paginator, info }, ref) => {
-    if (error) {
+    // Only show the error if there is no data
+    // Otherwise, the data is used from the cache and the error notification is shown in the parent component
+    if (error && !data) {
       return (
         <SuggestionsError
           size="md"


### PR DESCRIPTION
This PR changes error handling for Search to show the error panel only when there is no data available in the cache.
Otherwise, the existing data remains visible and an error notification is displayed.