### PR TITLE
Resource storage indexes and limits in authorization/token_info

### DIFF
--- a/seta-ui/seta_flask_server/blueprints/authorization/logic/token_info_logic.py
+++ b/seta-ui/seta_flask_server/blueprints/authorization/logic/token_info_logic.py
@@ -1,11 +1,16 @@
 from seta_flask_server.infrastructure.constants import ResourceTypeConstants
 from seta_flask_server.infrastructure.scope_constants import ResourceScopeConstants
 from seta_flask_server.repository.models import SetaUser
-from seta_flask_server.repository.interfaces import IResourcesBroker
+from seta_flask_server.repository.interfaces import (
+    IResourcesBroker,
+    IRollingIndexBroker,
+)
 
 
 def get_resource_permissions(
-    user: SetaUser, resources_broker: IResourcesBroker
+    user: SetaUser,
+    resources_broker: IResourcesBroker,
+    rolling_index_broker: IRollingIndexBroker,
 ) -> dict:
     """Build resource permissions."""
 
@@ -17,28 +22,58 @@ def get_resource_permissions(
                 lambda r: r.scope.lower() == ResourceScopeConstants.DataAdd.lower(),
                 user.resource_scopes,
             )
-            permissions["add"] = [
-                {"community_id": None, "resource_id": obj.id}
-                for obj in data_add_resources
-            ]
+            permissions["add"] = []
+            for scope in data_add_resources:
+                active_index_name = rolling_index_broker.get_active_index_for_resource(
+                    resource_id=scope.id
+                )
+                add_perm = {
+                    "community_id": None,
+                    "resource_id": scope.id,
+                    "indexes": [active_index_name],
+                }
+
+                resource = resources_broker.get_by_id(resource_id=scope.id)
+                if resource is not None and resource.limits is not None:
+                    add_perm["limits"] = resource.limits.to_json()
+
+                permissions["add"].append(add_perm)
 
             data_delete_resources = filter(
                 lambda r: r.scope.lower() == ResourceScopeConstants.DataDelete.lower(),
                 user.resource_scopes,
             )
-            permissions["delete"] = [
-                {"community_id": None, "resource_id": obj.id}
-                for obj in data_delete_resources
-            ]
+            permissions["delete"] = []
+            for scope in data_delete_resources:
+                storage_indexes = rolling_index_broker.get_storage_indexes_for_resource(
+                    resource_id=scope.id
+                )
+
+                permissions["delete"].append(
+                    {
+                        "community_id": None,
+                        "resource_id": scope.id,
+                        "indexes": list(storage_indexes),
+                    }
+                )
 
         # get queryable resource
         queryable_resources = resources_broker.get_all_queryable_by_user_id(
             user.user_id
         )
-        permissions["view"] = [
-            {"community_id": qr.community_id, "resource_id": qr.resource_id}
-            for qr in queryable_resources
-        ]
+        permissions["view"] = []
+        for qr in queryable_resources:
+            storage_indexes = rolling_index_broker.get_storage_indexes_for_resource(
+                resource_id=qr.resource_id
+            )
+
+            permissions["view"].append(
+                {
+                    "community_id": qr.community_id,
+                    "resource_id": qr.resource_id,
+                    "indexes": list(storage_indexes),
+                }
+            )
 
         # get representative resources
         representatives = resources_broker.get_all_by_member_id_and_type(

--- a/seta-ui/seta_flask_server/repository/interfaces/rolling_index_broker.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/rolling_index_broker.py
@@ -65,13 +65,13 @@ class IRollingIndexBroker(Interface):
 
         pass
 
-    def get_active_index(self, community_id: str) -> str:
-        """Active storage indexes for community.
+    def get_active_index_for_resource(self, resource_id: str) -> str:
+        """Active storage indexes for resource.
 
-        If this community has no rolling index assigned, then the default active index is returned instead.
+        If the resource community has no rolling index assigned, then the default active index is returned instead.
 
         Args:
-            community_id: Community identifier
+            resource_id: Resource identifier
 
         Returns:
             Name of the active storage index
@@ -79,17 +79,17 @@ class IRollingIndexBroker(Interface):
 
         pass
 
-    def get_storage_indexes_for_community(self, community_id: str) -> tuple[str]:
-        """All storage indexes that were assigned to community.
+    def get_storage_indexes_for_resource(self, resource_id: str) -> tuple[str]:
+        """All storage indexes that were assigned to resource community.
 
-        Searches for community identifier through all current and past community_ids collections.
+        Searches for resource's community identifier through all current and past community_ids collections.
         The storage names of the default rolling index are always appended to the return list.
 
         Args:
-            community_id: Community identifier
+            resource_id: Resource identifier
 
         Returns:
-            Name of all storage indexes where data can be found for the community resources.
+            Name of all storage indexes where data can be found for the resource community.
         """
 
         pass


### PR DESCRIPTION
New info added to resources permissions (check http://localhost/authorization/v1/doc).
"resource_permissions":

* "add" -> list of pairs {resource_id, indexes: list[str], limits: dict} - **one entry** indicating active storage index and storage limits for resource (size in megabytes)
Limits type: { "file_size_mb": int,  "total_files_no": int, "total_storage_mb": int     }

* "delete" -> list of pairs {resource_id, indexes: list[str]} - all storage indexes where data might reside
*
*  "view" -> list of pairs {resource_id, indexes: list[str]} - all storage indexes where data might reside