### PR TITLE
[seta-react] Add 'path' export for Library

### DIFF
--- a/seta-react/src/api/search/export.ts
+++ b/seta-react/src/api/search/export.ts
@@ -17,6 +17,12 @@ const EXPORT_API_PATH = '/export'
 
 const EXPORT_FILE_NAME_PREFIX = 'seta-export'
 
+// Extra field to return as part of the fields catalog to allow exporting the document's path
+const PATH_FIELD: ExportField = {
+  name: 'path',
+  description: 'The path(s) where the document is located in the library.'
+}
+
 export type FieldsCatalogResponse = {
   fields_catalog: ExportField[]
 }
@@ -27,7 +33,11 @@ type UseFieldsCatalogArgs = {
 }
 
 export type ExportMetaPayload = {
-  ids: string[]
+  ids: {
+    id: string
+    path: string
+  }[]
+
   fields: string[]
   format: ExportFormatKey
 }
@@ -39,7 +49,10 @@ export const fieldsCatalogQueryKey: QueryKey = ['fields-catalog']
 const getFieldsCatalog = async (config?: AxiosRequestConfig): Promise<FieldsCatalogResponse> => {
   const { data } = await api.get<FieldsCatalogResponse>(FIELDS_CATALOG_API_PATH, config)
 
-  return data
+  return {
+    // Add the `path` field to the catalog
+    fields_catalog: [...data.fields_catalog, PATH_FIELD]
+  }
 }
 
 export const useFieldsCatalog = (args?: UseFieldsCatalogArgs) => {

--- a/seta-react/src/components/PromptModal/PromptModal.tsx
+++ b/seta-react/src/components/PromptModal/PromptModal.tsx
@@ -14,6 +14,7 @@ type Props<T extends Value> = {
   label?: ReactNode
   placeholder?: string
   initialValue: T
+  invalidChars?: string[]
   optional?: boolean
   withStar?: boolean
   submitLabel?: string
@@ -32,6 +33,7 @@ const PromptModal = <T extends Value>(props: Props<T>) => {
     label = 'Enter a value',
     placeholder = 'Value',
     initialValue,
+    invalidChars,
     optional,
     withStar,
     submitLabel = 'Submit',
@@ -90,6 +92,12 @@ const PromptModal = <T extends Value>(props: Props<T>) => {
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (invalidChars?.includes(e.key)) {
+      e.preventDefault()
+
+      return
+    }
+
     if (e.key === 'Enter') {
       handleSubmit()
     } else if (e.key === 'Escape') {

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/ExportModal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/ExportModal.tsx
@@ -26,7 +26,7 @@ import SelectableFieldsGroup from './components/SelectableFieldsGroup'
 import SelectSection from './components/SelectSection'
 import SortableFieldsGroup from './components/SortableFieldsGroup'
 import SortedFieldsTitle from './components/SortedFieldsTitle'
-import { EXPORT_FORMATS } from './constants'
+import { EXPORT_FORMATS, EXPORT_PATHS_SEPARATOR } from './constants'
 import useExportStorage from './hooks/use-export-storage'
 import useSelectFields from './hooks/use-select-fields'
 import * as S from './styles'
@@ -107,9 +107,17 @@ const ExportModal = ({ reference, exportItems, opened, onClose, ...props }: Prop
 
     setIsExporting(true)
 
+    const ids: ExportMetaPayload['ids'] = exportItems.map(({ documentId, paths }) => ({
+      id: documentId,
+      // The same document can be located at multiple paths, so we join them here
+      path: paths.join(EXPORT_PATHS_SEPARATOR)
+    }))
+
+    const fields: ExportMetaPayload['fields'] = sortedFields.map(({ name }) => name)
+
     const payload: ExportMetaPayload = {
-      ids: exportItems.map(({ documentId }) => documentId),
-      fields: sortedFields.map(({ name }) => name),
+      ids,
+      fields,
       format
     }
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/constants.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/constants.ts
@@ -11,3 +11,5 @@ export const EXPORT_FORMATS: ExportSelectItem[] = [
     label: ExportMimeType.json.name
   }
 ]
+
+export const EXPORT_PATHS_SEPARATOR = '; '

--- a/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-export-storage.ts
+++ b/seta-react/src/pages/SearchPageNew/components/documents/ExportModal/hooks/use-export-storage.ts
@@ -1,11 +1,12 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useEffect } from 'react'
 
-import updateSelectedStates from '~/pages/SearchPageNew/components/documents/ExportModal/utils/update-selected-states'
 import { STORAGE_KEY } from '~/pages/SearchPageNew/utils/constants'
 
 import type { ExportField, ExportFormatKey, ExportStorage } from '~/types/library/library-export'
 import { storage } from '~/utils/storage-utils'
+
+import updateSelectedStates from '../utils/update-selected-states'
 
 const exportStorage = storage<ExportStorage>(STORAGE_KEY.EXPORT)
 

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NewFolderAction/NewFolderAction.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/components/NewFolderAction/NewFolderAction.tsx
@@ -8,6 +8,7 @@ import { ROOT_NODE_ID } from '~/pages/SearchPageNew/components/documents/Library
 
 import { useCreateNewFolder } from '~/api/search/library'
 import type { LibraryItem } from '~/types/library/library-item'
+import { INVALID_PATH_CHARACTERS } from '~/utils/library-utils'
 
 import * as S from './styles'
 
@@ -70,6 +71,12 @@ const NewFolderAction = ({
   }
 
   const handleInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = e => {
+    if (INVALID_PATH_CHARACTERS.includes(e.key)) {
+      e.preventDefault()
+
+      return
+    }
+
     if (e.key === 'Enter') {
       submitNewFolder()
     }

--- a/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-rename-modal.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/LibraryTree/hooks/use-rename-modal.tsx
@@ -7,6 +7,7 @@ import PromptModal from '~/components/PromptModal'
 import { useUpdateItem } from '~/api/search/library'
 import useComplexModalState from '~/hooks/use-complex-modal-state'
 import type { LibraryItem } from '~/types/library/library-item'
+import { INVALID_PATH_CHARACTERS } from '~/utils/library-utils'
 import { notifications } from '~/utils/notifications'
 
 import { getFolderPath } from '../utils'
@@ -100,6 +101,7 @@ const useRenameModal = () => {
       placeholder="Folder name"
       submitLabel="Rename folder"
       initialValue={folder?.title ?? ''}
+      invalidChars={INVALID_PATH_CHARACTERS}
       onClose={closeModal}
       onSubmit={handleSubmit}
     />

--- a/seta-react/src/utils/library-utils.ts
+++ b/seta-react/src/utils/library-utils.ts
@@ -1,7 +1,14 @@
 import type { LibraryItemExport } from '~/types/library/library-export'
 import { LibraryItemType, type LibraryItem } from '~/types/library/library-item'
 
+// The name of the root library item to display in the UI
 export const ROOT_LIBRARY_ITEM_NAME = 'My Library'
+
+// Characters that are not allowed in folder names, to avoid confusion in the UI and in the exported files
+export const INVALID_PATH_CHARACTERS = ['/', '\\', '"', ',', ';']
+
+// The path to use as the root library folder in the exported files
+const HOME_PATH = '~'
 
 export const getDocumentsForExport = (libraryItem: LibraryItem): LibraryItemExport[] => {
   const dict: Map<string, LibraryItemExport> = new Map()
@@ -17,12 +24,16 @@ export const getDocumentsForExport = (libraryItem: LibraryItem): LibraryItemExpo
         }
 
         // Remove the last item from the path, which is the document name
-        const formattedPath = path.slice(0, -1).join(' / ')
+        const curatedPath = path.slice(0, -1).join('/')
 
+        const formattedPath = curatedPath ? `${HOME_PATH}/${curatedPath}` : HOME_PATH
+
+        // Add all the unique paths where this document is located at in the library
         if (!value.paths.includes(formattedPath)) {
           value.paths.push(formattedPath)
         }
 
+        // Keep the records unique by `documentId`
         dict.set(documentId, value)
       }
     } else {


### PR DESCRIPTION
This PR adds support on the front-end to export the `path` field in the Library.