### PR TITLE
Repository implementation for unsearchable data sources

### DIFF
--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources.py
@@ -82,9 +82,11 @@ class DataSourcesResource(Resource):
         security="CSRF",
     )
     @data_sources_ns.expect(dto.new_data_source_model)
-    @data_sources_ns.response(int(HTTPStatus.CREATED), "", dto.response_message_model)
     @data_sources_ns.response(
-        int(HTTPStatus.BAD_REQUEST), "Bad payload", dto.error_model
+        int(HTTPStatus.CREATED), "", dto.response_dto.response_message_model
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.BAD_REQUEST), "Bad payload", dto.response_dto.error_model
     )
     @jwt_required()
     def post(self):
@@ -126,7 +128,7 @@ class DataSourcesResource(Resource):
     "/<string:data_source_id>", endpoint="admin_data_source", methods=["PUT"]
 )
 @data_sources_ns.param("data_source_id", "Data source identifier")
-@data_sources_ns.response(int(HTTPStatus.BAD_REQUEST), "", dto.error_model)
+@data_sources_ns.response(int(HTTPStatus.BAD_REQUEST), "", dto.response_dto.error_model)
 class DataSourceResource(Resource):
     """Handles HTTP requests to URL: /admin/data-sources/{data_source_id}."""
 
@@ -154,7 +156,9 @@ class DataSourceResource(Resource):
         },
         security="CSRF",
     )
-    @data_sources_ns.response(int(HTTPStatus.OK), "", dto.response_message_model)
+    @data_sources_ns.response(
+        int(HTTPStatus.OK), "", dto.response_dto.response_message_model
+    )
     @data_sources_ns.expect(dto.update_data_source_model)
     @jwt_required()
     def put(self, data_source_id: str):

--- a/seta-ui/seta_flask_server/blueprints/admin/models/data_source_dto.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/models/data_source_dto.py
@@ -1,10 +1,6 @@
 from flask_restx import Model, fields
-
-from seta_flask_server.infrastructure.dto.response_dto import (
-    error_model,
-    error_fields_model,
-    response_message_model,
-)
+from seta_flask_server.infrastructure.dto import response_dto
+from seta_flask_server.infrastructure.dto import datetime_format
 
 from seta_flask_server.infrastructure.constants import DataSourceStatusConstants
 
@@ -56,6 +52,9 @@ view_data_source_model = data_source_model.clone(
             model=user_info_model, description="Creator", skip_none=True
         ),
         "status": status_field,
+        "created": datetime_format.DateISOFormat(
+            "Creation date in SeTA system.", attribute="created_at"
+        ),
     },
 )
 
@@ -75,7 +74,7 @@ ns_models = {
     update_data_source_model.name: update_data_source_model,
     view_data_source_model.name: view_data_source_model,
     new_data_source_model.name: new_data_source_model,
-    error_fields_model.name: error_fields_model,
-    error_model.name: error_model,
-    response_message_model.name: response_message_model,
+    response_dto.error_fields_model.name: response_dto.error_fields_model,
+    response_dto.error_model.name: response_dto.error_model,
+    response_dto.response_message_model.name: response_dto.response_message_model,
 }

--- a/seta-ui/seta_flask_server/blueprints/data_sources/models/data_source_dto.py
+++ b/seta-ui/seta_flask_server/blueprints/data_sources/models/data_source_dto.py
@@ -1,4 +1,6 @@
 from flask_restx import Model, fields
+from seta_flask_server.infrastructure.dto import datetime_format
+
 
 contact_model = Model(
     "DataSourceContact",
@@ -20,6 +22,10 @@ data_source_model = Model(
         "contact": fields.Nested(
             model=contact_model, description="Contact channels", skip_none=True
         ),
+        "created": datetime_format.DateISOFormat(
+            "Creation date in SeTA system.", attribute="created_at"
+        ),
+        "searchable": fields.Boolean(description="Is searchable for this user?"),
     },
 )
 

--- a/seta-ui/seta_flask_server/blueprints/profile/__init__.py
+++ b/seta-ui/seta_flask_server/blueprints/profile/__init__.py
@@ -7,6 +7,7 @@ from .apps import applications_ns
 from .scopes import scopes_ns
 from .resources import resources_ns
 from .library import library_ns
+from .unsearchables import unsearchables_ns
 
 authorizations = {
     "Bearer": {
@@ -44,3 +45,5 @@ profile_api.add_namespace(applications_ns, path="/me/apps")
 profile_api.add_namespace(scopes_ns, path="/me")
 profile_api.add_namespace(resources_ns, path="/me")
 profile_api.add_namespace(library_ns, path="/me")
+
+profile_api.add_namespace(unsearchables_ns, path="/me")

--- a/seta-ui/seta_flask_server/blueprints/profile/models/unsearchables_dto.py
+++ b/seta-ui/seta_flask_server/blueprints/profile/models/unsearchables_dto.py
@@ -1,0 +1,29 @@
+from flask_restx import Model, fields
+from seta_flask_server.infrastructure.dto import response_dto
+
+data_source_model = Model(
+    "DataSource",
+    {
+        "id": fields.String(
+            description="Resource identifier", attribute="data_source_id"
+        ),
+        "title": fields.String(description="Resource title"),
+    },
+)
+
+update_model = Model(
+    "Unsearchables",
+    {
+        "dataSourceIds": fields.List(
+            fields.String, description="List of data source identifiers"
+        )
+    },
+)
+
+ns_models = {
+    data_source_model.name: data_source_model,
+    update_model.name: update_model,
+    response_dto.error_fields_model.name: response_dto.error_fields_model,
+    response_dto.error_model.name: response_dto.error_model,
+    response_dto.response_message_model.name: response_dto.response_message_model,
+}

--- a/seta-ui/seta_flask_server/blueprints/profile/unsearchables.py
+++ b/seta-ui/seta_flask_server/blueprints/profile/unsearchables.py
@@ -1,0 +1,132 @@
+from http import HTTPStatus
+from datetime import datetime
+import pytz
+from injector import inject
+
+from werkzeug.exceptions import BadRequest
+
+from flask import jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from flask_restx import Namespace, Resource
+
+from seta_flask_server.repository import interfaces
+from seta_flask_server.repository import models
+
+from .models import unsearchables_dto as dto
+
+unsearchables_ns = Namespace(
+    "Unsearchables data sources", description="Profile unsearchable data sources"
+)
+unsearchables_ns.models.update(dto.ns_models)
+
+
+@unsearchables_ns.route(
+    "/unsearchables", endpoint="me_unsearchables", methods=["GET", "POST"]
+)
+class UnsearchablesResource(Resource):
+    """Handles HTTP requests to URL: /me/unsearchables."""
+
+    @inject
+    def __init__(
+        self,
+        profile_broker: interfaces.IUserProfileUnsearchables,
+        data_sources_broker: interfaces.IDataSourcesBroker,
+        *args,
+        api=None,
+        **kwargs,
+    ):
+        self.profile_broker = profile_broker
+        self.data_sources_broker = data_sources_broker
+
+        super().__init__(api, *args, **kwargs)
+
+    @unsearchables_ns.doc(
+        description="Retrieve restricted data sources for this user.",
+        responses={int(HTTPStatus.OK): "'Retrieved restricted data sources."},
+        security="CSRF",
+    )
+    @unsearchables_ns.marshal_list_with(dto.data_source_model, mask="*", skip_none=True)
+    @jwt_required()
+    def get(self):
+        """Retrieve restricted data sources for the authenticated user"""
+
+        identity = get_jwt_identity()
+        user_id = identity["user_id"]
+
+        ids = self.profile_broker.get_unsearchables(user_id)
+
+        if not ids:
+            return None
+
+        unsearchables = []
+
+        for data_source_id in ids:
+            data_source = self.data_sources_broker.get_by_id(
+                data_source_id=data_source_id
+            )
+
+            if data_source is None:
+                unsearchables.append(
+                    {
+                        "data_source_id": data_source_id,
+                        "title": data_source_id,
+                    }
+                )
+            else:
+                unsearchables.append(
+                    {"data_source_id": data_source_id, "title": data_source.title}
+                )
+
+        return unsearchables
+
+    @unsearchables_ns.doc(
+        description="Manage restricted data sources for the authenticated user.",
+        responses={
+            int(HTTPStatus.OK): "Restricted data sources updated.",
+            int(HTTPStatus.BAD_REQUEST): "Errors in request payload",
+        },
+        security="CSRF",
+    )
+    @unsearchables_ns.expect(dto.update_model)
+    @unsearchables_ns.response(
+        int(HTTPStatus.OK), "", dto.response_dto.response_message_model
+    )
+    @unsearchables_ns.response(
+        int(HTTPStatus.BAD_REQUEST), "", dto.response_dto.error_model
+    )
+    @jwt_required()
+    def post(self):
+        """
+        Manage restricted data sources for the authenticated user.
+        Send empty array for deletion.
+        """
+
+        identity = get_jwt_identity()
+        user_id = identity["user_id"]
+
+        request_dict = unsearchables_ns.payload
+        if "dataSourceIds" in request_dict:
+            data_source_ids = request_dict["dataSourceIds"]
+        else:
+            e = BadRequest()
+            e.data = {
+                "message": "Field 'dataSourceIds' is missing from request payload.",
+                "errors": {"dataSourceIds": "Field is missing."},
+            }
+            raise e
+
+        if not data_source_ids:
+            self.profile_broker.delete_unsearchables(user_id)
+            message = "Restricted list deleted"
+        else:
+            self.profile_broker.upsert_unsearchables(
+                models.UnsearchablesModel(
+                    user_id=user_id,
+                    data_sources=data_source_ids,
+                    timestamp=datetime.now(tz=pytz.utc),
+                )
+            )
+
+            message = "Unsearchable list updated."
+
+        return jsonify(status="success", message=message)

--- a/seta-ui/seta_flask_server/dependency.py
+++ b/seta-ui/seta_flask_server/dependency.py
@@ -47,7 +47,12 @@ class MongoDbClientModule(injector.Module):
         binder.bind(
             interfaces.IRollingIndexBroker, to=implementation.RollingIndexBroker
         )
+
         binder.bind(interfaces.IDataSourcesBroker, to=implementation.DataSourcesBroker)
+        binder.bind(
+            interfaces.IUserProfileUnsearchables,
+            to=implementation.UserProfileUnsearchables,
+        )
 
     def create_client(self) -> interfaces.IDbConfig:
         """Create configuration client"""

--- a/seta-ui/seta_flask_server/infrastructure/dto/datetime_format.py
+++ b/seta-ui/seta_flask_server/infrastructure/dto/datetime_format.py
@@ -1,0 +1,7 @@
+import datetime as dt
+from flask_restx import fields
+
+
+class DateISOFormat(fields.Raw):
+    def format(self, value: dt.datetime):
+        return value.isoformat()

--- a/seta-ui/seta_flask_server/repository/interfaces/__init__.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/__init__.py
@@ -17,4 +17,6 @@ from .library_broker import ILibraryBroker
 from .users_query_broker import IUsersQueryBroker
 from .external_provider_broker import IExternalProviderBroker
 from .rolling_index_broker import IRollingIndexBroker
+
 from .data_sources_broker import IDataSourcesBroker
+from .user_profile_unsearchables import IUserProfileUnsearchables

--- a/seta-ui/seta_flask_server/repository/interfaces/user_profile_unsearchables.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/user_profile_unsearchables.py
@@ -1,0 +1,20 @@
+from interface import Interface
+from seta_flask_server.repository.models import UnsearchablesModel
+
+
+class IUserProfileUnsearchables(Interface):
+    # ------un-searchable resources ----#
+
+    def get_unsearchables(self, user_id: str) -> list[str]:
+        """Un-searchable data source ids for the specified user."""
+        pass
+
+    def upsert_unsearchables(self, unsearchable: UnsearchablesModel):
+        """Updates/Inserts restricted searchable data sources."""
+        pass
+
+    def delete_unsearchables(self, user_id: str):
+        """Deletes restricted searchable resources."""
+        pass
+
+    # ---------------------------------#

--- a/seta-ui/seta_flask_server/repository/models/__init__.py
+++ b/seta-ui/seta_flask_server/repository/models/__init__.py
@@ -24,4 +24,6 @@ from .library import LibraryItem, LibraryItemType
 from .account_info import AccountInfo
 from .catalogue_field import CatalogueField
 from .rolling_index import StorageLimits, StorageIndex, RollingIndex
+
 from .data_source import DataSourceContactModel, DataSourceModel
+from .profile import UnsearchablesModel

--- a/seta-ui/seta_flask_server/repository/models/profile/__init__.py
+++ b/seta-ui/seta_flask_server/repository/models/profile/__init__.py
@@ -1,0 +1,1 @@
+from .unsearchables import UnsearchablesModel

--- a/seta-ui/seta_flask_server/repository/models/profile/unsearchables.py
+++ b/seta-ui/seta_flask_server/repository/models/profile/unsearchables.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class UnsearchablesModel(BaseModel):
+    user_id: str
+    data_sources: list[str] = Field(default_factory=list)
+    timestamp: datetime = None

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/__init__.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/__init__.py
@@ -18,4 +18,6 @@ from .db_library_broker import LibraryBroker
 from .db_users_query_broker import UsersQueryBroker
 from .db_external_provider_broker import ExternalProviderBroker
 from .db_rolling_index_broker import RollingIndexBroker
+
 from .db_data_sources_broker import DataSourcesBroker
+from .profile import UserProfileUnsearchables

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/profile/__init__.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/profile/__init__.py
@@ -1,0 +1,1 @@
+from .db_user_profile_unsearchables import UserProfileUnsearchables

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/profile/db_user_profile_unsearchables.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/profile/db_user_profile_unsearchables.py
@@ -1,0 +1,34 @@
+# pylint: disable=missing-function-docstring
+from interface import implements
+from injector import inject
+
+from seta_flask_server.repository.interfaces import IDbConfig, IUserProfileUnsearchables
+from seta_flask_server.repository.models import UnsearchablesModel
+
+
+class UserProfileUnsearchables(implements(IUserProfileUnsearchables)):
+    @inject
+    def __init__(self, config: IDbConfig) -> None:
+        self.db = config.get_db()
+        self.collection = self.db["user-profile-unsearchables"]
+
+    def get_unsearchables(self, user_id: str) -> list[str]:
+        profile = self.collection.find_one({"user_id": user_id})
+
+        if profile and "data_sources" in profile:
+            return profile["data_sources"]
+
+        return None
+
+    def upsert_unsearchables(self, unsearchable: UnsearchablesModel):
+        query_filter = {"user_id": unsearchable.user_id}
+
+        if self.collection.count_documents(query_filter, limit=1) > 0:
+            self.collection.update_one(
+                query_filter, {"$set": unsearchable.model_dump(exclude={"user_id"})}
+            )
+        else:
+            self.collection.insert_one(unsearchable.model_dump())
+
+    def delete_unsearchables(self, user_id: str):
+        self.collection.delete_one({"user_id": user_id})


### PR DESCRIPTION
New endpoint for managing unsearchable sources for user: _/me/unsearchables_.
Documentation _http://localhost/seta-ui/api/v1/me/doc_

New fields for view data source list: **created** date & **searchable** flag.
Documentation _http://localhost/seta-ui/api/v1/data-sources/doc_