### PR TITLE
[seta-react] Add versioning for React app

### DIFF
--- a/seta-react/package.json
+++ b/seta-react/package.json
@@ -1,13 +1,17 @@
 {
   "name": "seta-app",
-  "version": "0.1.0",
+  "version": "2.0.5",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postversion": "node ./scripts/version-tag-commit.js",
     "start": "vite",
     "build": "tsc && vite build",
     "lint": "eslint --ext ts,tsx . --color",
     "lint:fix": "eslint --ext ts,tsx . --color --fix",
+    "bump": "pnpm version minor",
+    "bump:patch": "pnpm version patch",
+    "bump:major": "pnpm version major",
     "prepare": "cd .. && husky install ./seta-react/.husky",
     "docker:build": "cd ../seta-compose && docker compose -f docker-compose.yml -f docker-compose-dev.yml --env-file .env.dev build",
     "docker:build:prod": "cd ../seta-compose && docker compose build",

--- a/seta-react/scripts/version-tag-commit.js
+++ b/seta-react/scripts/version-tag-commit.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+
+// Get the version from package.json
+const version = process.env.npm_package_version
+
+console.log(`Bumping version to '${version}'...\n`)
+
+const exec = require('child_process').execSync
+
+// Run git commands to commit and tag the new version
+exec('git add package.json')
+exec(`git commit -m "Bump version to ${version}"`)
+exec(`git tag v${version}`)
+
+// Push the commit and the tag
+exec('git push && git push --tags')
+
+console.log(`\n✅ Tagged and pushed 'v${version}'`)

--- a/seta-react/src/components/Footer/Footer.tsx
+++ b/seta-react/src/components/Footer/Footer.tsx
@@ -1,6 +1,8 @@
 import { RiShareBoxFill } from 'react-icons/ri'
 import { useNavigate } from 'react-router-dom'
 
+import Version from '~/components/Version'
+
 import * as S from './styles'
 
 const Footer = () => {
@@ -14,6 +16,10 @@ const Footer = () => {
           <li className="title">Joint Research Centre Semantic Text Analysis (SeTA)</li>
           <li />
           <li className="description">This site is managed by the Joint Research Centre</li>
+
+          <li>
+            <Version color="white" css={S.version} />
+          </li>
         </ul>
 
         <ul css={S.section}>

--- a/seta-react/src/components/Footer/styles.ts
+++ b/seta-react/src/components/Footer/styles.ts
@@ -75,3 +75,7 @@ export const section: ThemedCSS = theme => css`
 export const withDivider: ThemedCSS = theme => css`
   border-top: 1px solid ${theme.colors.gray[0]};
 `
+
+export const version = css`
+  opacity: 0.4;
+`

--- a/seta-react/src/components/Version/Version.tsx
+++ b/seta-react/src/components/Version/Version.tsx
@@ -1,0 +1,20 @@
+import { Text, type DefaultMantineColor } from '@mantine/core'
+
+import type { ClassNameProp } from '~/types/children-props'
+
+// Read the version defined by Vite - see `vite.config.js`
+const version = APP_VERSION
+
+type Props = {
+  color?: 'black' | 'white' | DefaultMantineColor
+} & ClassNameProp
+
+const Version = ({ color = 'dark', className }: Props) => {
+  return (
+    <Text size="xs" color={color} className={className}>
+      v{version}
+    </Text>
+  )
+}
+
+export default Version

--- a/seta-react/src/components/Version/index.ts
+++ b/seta-react/src/components/Version/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Version'

--- a/seta-react/src/vite-env.d.ts
+++ b/seta-react/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const APP_VERSION: string

--- a/seta-react/vite.config.js
+++ b/seta-react/vite.config.js
@@ -23,6 +23,21 @@ const checkerDev = {
   }
 }
 
+// Common `define` configuration for both development and production
+/** @type {import('vite').UserConfig['define']} */
+const commonDefine = {
+  APP_VERSION: JSON.stringify(process.env.npm_package_version)
+}
+
+// `define` configuration for development
+/** @type {import('vite').UserConfig['define']} */
+const devDefine = {
+  // Some libraries use the global object, even though it doesn't exist in the browser.
+  // Alternatively, we could add `<script>window.global = window;</script>` to index.html.
+  // https://github.com/vitejs/vite/discussions/5912
+  global: {}
+}
+
 export default defineConfig(({ mode }) => {
   const isBuild = mode === 'production'
   const isDev = mode === 'development'
@@ -35,14 +50,11 @@ export default defineConfig(({ mode }) => {
 
       checker(isBuild ? checkerProd : checkerDev)
     ],
-    define: isDev
-      ? {
-          // Some libraries use the global object, even though it doesn't exist in the browser.
-          // Alternatively, we could add `<script>window.global = window;</script>` to index.html.
-          // https://github.com/vitejs/vite/discussions/5912
-          global: {}
-        }
-      : null,
+    define: {
+      ...commonDefine,
+      // Replace `undefined` with production specific configuration if needed
+      ...(isDev ? devDefine : undefined)
+    },
     server: {
       host: 'localhost',
       port: 3000,


### PR DESCRIPTION
This PR introduces versioning for the frontend app.

There are three new scripts (described below) that can be used to automatically increase the version number.

Each of them performs the following actions:
- Increase the version number and save it to `package.json`
- Create a new commit and push the updated file
- Tag the commit with the new version number and push the tag

We use semantic versioning, with the following format: `<major>.<minor>.<patch>`

To run the scripts, `Node.js 18` and [pnpm](https://pnpm.io/installation) must be installed locally.
The scripts are:

- `pnpm bump` - automatically increases the `minor` part of the version number. If the previous version was `2.0.5`, running this updates the version to `2.1.0`.
- `pnpm bump:patch` - automatically increases the `patch` part of the version number.
- `pnpm bump:major` - automatically increases the `major` part of the version number.

After bumping the version, running `docker compose build seta-ui-react` builds the production Docker image with the new version number embedded within.

For convenience, we can also run `pnpm docker:build:prod seta-ui-react` from the React app's folder.