### PR TITLE
[seta-react] Remove search auto-refresh & add Filters loading

### DIFF
--- a/seta-react/src/api/search/documents.ts
+++ b/seta-react/src/api/search/documents.ts
@@ -105,6 +105,8 @@ export const useDocuments = (
     // The vectors in the query are identified by the `embeddingsKey` array
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: queryKey.docs(query, embeddingsKey, page, perPage, searchOptions),
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000, // 5 minutes
 
     queryFn: ({ signal }) =>
       getDocuments(

--- a/seta-react/src/pages/SearchPageNew/SearchPageNew.tsx
+++ b/seta-react/src/pages/SearchPageNew/SearchPageNew.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Flex } from '@mantine/core'
+import { useQueryClient } from '@tanstack/react-query'
 
 import Page from '~/components/Page'
 import { StagedDocumentsProvider } from '~/pages/SearchPageNew/contexts/staged-documents-context'
@@ -9,7 +10,12 @@ import type {
   QueryAggregationContract
 } from '~/pages/SearchWithFilters/types/contracts'
 
-import { useDocuments, type DocumentsOptions, type DocumentsResponse } from '~/api/search/documents'
+import {
+  useDocuments,
+  type DocumentsOptions,
+  type DocumentsResponse,
+  queryKey as documentsQueryKey
+} from '~/api/search/documents'
 import type { Crumb } from '~/types/breadcrumbs'
 import { getSearchQueryAndTerms } from '~/utils/search-utils'
 import { storage } from '~/utils/storage-utils'
@@ -30,13 +36,20 @@ const SearchPageNew = () => {
   const [searchOptions, setSearchOptions] = useState<DocumentsOptions | undefined>(undefined)
   const [queryContract, setQueryContract] = useState<QueryAggregationContract | null>(null)
   const [enrichLoading, setEnrichLoading] = useState(false)
+  const [page, setPage] = useState(1)
 
   const [loadDocsForFilters, setLoadDocsForFilters] = useState(false)
 
+  const queryClient = useQueryClient()
+
+  // Only used to load the initial data for the filters if there is no saved search
   useDocuments(undefined, undefined, {
     enabled: loadDocsForFilters,
 
     onSuccess: docs => {
+      // Reset the flag once the data is loaded to disable the query
+      setLoadDocsForFilters(false)
+
       handleDocumentsChanged(docs)
     }
   })
@@ -50,6 +63,12 @@ const SearchPageNew = () => {
     }
 
     setLoadDocsForFilters(true)
+
+    // Invalidate the initial documents query to force a new request when no saved search is present
+    queryClient.invalidateQueries([documentsQueryKey.root, {}])
+
+    // queryClient does not represent a real dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleSearch = async ({ tokens, enrichedStatus, embeddings }: SearchValue) => {
@@ -58,7 +77,12 @@ const SearchPageNew = () => {
     const { query: value, terms } = await getSearchQueryAndTerms(tokens, enrichedStatus)
 
     setEnrichLoading(false)
+
+    setPage(1)
     setQuery({ value, terms, embeddings })
+
+    // Refresh the documents list if the query is stale
+    queryClient.refetchQueries({ queryKey: [documentsQueryKey.root], stale: true, type: 'active' })
   }
 
   const handleApplyFilter = (value: AdvancedFiltersContract) => {
@@ -97,6 +121,8 @@ const SearchPageNew = () => {
               <DocumentsTab
                 query={query}
                 searchOptions={searchOptions}
+                page={page}
+                onPageChange={setPage}
                 onDocumentsChanged={handleDocumentsChanged}
               />
             </SearchResults>

--- a/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/DocumentsTab.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/SearchResultsTabs/components/DocumentsTab/DocumentsTab.tsx
@@ -20,10 +20,12 @@ const uploadsStorage = storage<unknown[]>(STORAGE_KEY.UPLOADS)
 type Props = {
   query: SearchState
   searchOptions: DocumentsOptions | undefined
+  page: number
+  onPageChange: (page: number) => void
   onDocumentsChanged?: (docs: DocumentsResponse) => void
 }
 
-const DocumentsTab = ({ query, searchOptions, onDocumentsChanged }: Props) => {
+const DocumentsTab = ({ query, searchOptions, page, onPageChange, onDocumentsChanged }: Props) => {
   // If there is a saved search, prepare the loading state
   const initialLoading = useMemo(
     () => !query && (!!searchStorage.read() || !!uploadsStorage.read()?.length),
@@ -36,6 +38,8 @@ const DocumentsTab = ({ query, searchOptions, onDocumentsChanged }: Props) => {
       terms={query.terms}
       embeddings={query.embeddings}
       searchOptions={searchOptions}
+      page={page}
+      onPageChange={onPageChange}
       onDocumentsChanged={onDocumentsChanged}
     />
   )

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentsList/DocumentsList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useEnrichLoading } from '~/pages/SearchPageNew/contexts/enrich-loading-context'
 
@@ -17,18 +17,27 @@ type Props = {
   terms: string[]
   embeddings?: EmbeddingInfo[]
   searchOptions?: DocumentsOptions
+  page: number
+  onPageChange: (page: number) => void
   onDocumentsChanged?: (documents: DocumentsResponse) => void
 }
 
-const DocumentsList = ({ query, terms, embeddings, searchOptions, onDocumentsChanged }: Props) => {
+const DocumentsList = ({
+  query,
+  terms,
+  embeddings,
+  searchOptions,
+  page,
+  onPageChange,
+  onDocumentsChanged
+}: Props) => {
   const documentsChangedRef = useRef(onDocumentsChanged)
   const errorNotificationShownRef = useRef(false)
 
-  const [page, setPage] = useState(1)
-
   const { loading: enrichLoading } = useEnrichLoading()
 
-  const { data, isLoading, error, refetch } = useDocuments(query, embeddings, {
+  // Using `isFetching` to also show the loading state when there is data in the cache
+  const { data, isFetching, error, refetch } = useDocuments(query, embeddings, {
     page,
     perPage: PER_PAGE,
     searchOptions
@@ -65,14 +74,14 @@ const DocumentsList = ({ query, terms, embeddings, searchOptions, onDocumentsCha
     },
     resetPageDependencies: [query, searchOptions],
     scrollOffset: 80,
-    onPageChange: setPage
+    onPageChange
   })
 
   return (
     <DocumentsListContent
       ref={scrollTargetRef}
       data={data}
-      isLoading={isLoading || enrichLoading}
+      isLoading={isFetching || enrichLoading}
       error={error}
       onTryAgain={refetch}
       queryTerms={terms}

--- a/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
+++ b/seta-react/src/pages/SearchWithFilters/components/FiltersPanel/FiltersPanel.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
-import { Container, Flex, Accordion, ScrollArea, rem, Text, Box } from '@mantine/core'
+import {
+  Container,
+  Flex,
+  Accordion,
+  ScrollArea,
+  rem,
+  Text,
+  Box,
+  LoadingOverlay
+} from '@mantine/core'
 
 import AccordionItem from '~/components/Accordion/AccordionItem'
 import AccordionPanel from '~/components/Accordion/AccordionPanel'
@@ -53,6 +62,9 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
   useEffect(() => {
     statusChangeRef.current?.(status.status)
   }, [status])
+
+  // Show the loading overlay while the initial query is loading
+  const isLoading = !queryContract
 
   const handleApplyFilters = () => {
     const contract = buildFiltersContract({
@@ -160,6 +172,8 @@ const FiltersPanel = ({ queryContract, onApplyFilter, onStatusChange }: Advanced
   // TODO: Split this into multiple components
   return (
     <Flex direction="column" align="center" gap="xl">
+      <LoadingOverlay visible={isLoading} overlayBlur={2} />
+
       <ApplyFilters
         status={status}
         onApplyFilters={handleApplyFilters}


### PR DESCRIPTION
This PR adds the following improvements:

- Removed the auto-refresh of the Search queries
- Changed to refetch the documents manually when pressing the `Search` button after the query becomes stale (5 minutes)
- Added a loading overlay over the Filters when loading while entering the page
- Fixed a bug that displayed empty filters when there was no saved search and the user changed to another page and back to Search
- Changed to move to page `1` whenever pressing the Search button