### PR TITLE
Data sources and search index apis

### DIFF
--- a/seta-admin/admin/routers/indexes.py
+++ b/seta-admin/admin/routers/indexes.py
@@ -51,7 +51,7 @@ async def create_index(
 
 
 @router.delete(
-    "/indexes/{index_name}",
+    "/indexes",
     status_code=status.HTTP_200_OK,
     response_model=ResponseMessage,
     responses={
@@ -61,19 +61,19 @@ async def create_index(
     },
 )
 async def delete_index(
-    index_name: str,
+    index: Index,
     client: opensearch.OpenSearchEngine = Depends(opensearch.get_search_client),
 ):
     """Deletes index and all its data from Search engine."""
 
-    if not await client.index_exists(name=index_name):
+    if not await client.index_exists(name=index.name):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"name": "Index not found."},
         )
 
     try:
-        await client.delete_index(name=index_name)
+        await client.delete_index(name=index.name)
 
         return ResponseMessage(status=ResponseStatus.SUCCESS, message="Index deleted.")
     except Exception as ex:

--- a/seta-api/seta_api/infrastructure/auth_validator.py
+++ b/seta-api/seta_api/infrastructure/auth_validator.py
@@ -3,61 +3,66 @@ from flask_jwt_extended import get_jwt, verify_jwt_in_request
 from flask import jsonify
 from seta_api.infrastructure.ApiLogicError import ForbiddenResourceError
 
+
 def auth_validator(role=None):
     def wrapper(fn):
         @wraps(fn)
-        def decorator(*args, **kwargs):                       
+        def decorator(*args, **kwargs):
             verify_jwt_in_request()
-            
+
             if role:
                 claims = get_jwt()
-                
-                if not (claims['role'] == role):
+
+                if not (claims["role"] == role):
                     response = jsonify({"message": "Unauthorized access"})
                     response.status_code = 403
                     return response
-            
+
             return fn(*args, **kwargs)
-           
+
         return decorator
+
     return wrapper
 
 
 def validate_view_permissions(sources: list[str]) -> list[str]:
-    '''
+    """
     Verify that all resources in the `sources` are contained by the resource_permissions.view array of the decoded token.
     Return the list of view resources if `sources` are empty
-    '''
-    
+    """
+
     view_resources = get_resource_permissions("view")
 
-    #user has no access to any public or community resources
-    if not view_resources:   
+    # user has no access to any public or community resources
+    if not view_resources:
         raise ForbiddenResourceError(resource_id=None)
-    
-     #restrict query only to view_resources
+
+    # restrict query only to view_resources
     if sources is None:
         return [r["resource_id"] for r in view_resources]
     else:
         for s in sources:
             if not any(r["resource_id"].lower() == s.lower() for r in view_resources):
                 raise ForbiddenResourceError(resource_id=s)
-    
+
     return sources
 
+
 def validate_add_permission(source: str) -> bool:
-    '''
-    Validate that the `source` is contained by the resource_permissions.add array of the decoded token
-    '''
-    
-    return _validate_source_permission(source=source, permission="add")
+    """
+    Validate that the `source` is contained by the resource_permissions.ownership array of the decoded token
+    """
+
+    return _validate_source_permission(source=source, permission="ownership")
+
 
 def validate_delete_permission(source: str) -> bool:
-    '''
-    Validate that the `source` is contained by the resource_permissions.delete array of the decoded token
-    '''
-    
-    return _validate_source_permission(source=source, permission="delete")
+    """
+    Validate that the `source` is contained by the resource_permissions.ownership array of the decoded token
+    """
+
+    return _validate_source_permission(source=source, permission="ownership")
+
 
 def get_resource_permissions(permission: str) -> list[dict]:
     """
@@ -66,22 +71,23 @@ def get_resource_permissions(permission: str) -> list[dict]:
     Important: 'add' & 'delete' lists have value only for the resource_id property
 
     :param permission:
-        One of 'view', 'add', 'delete', 'representatives'
+        One of 'view', 'ownership'
     """
 
     jwt = get_jwt()
     permissions = jwt.get("resource_permissions", None)
     if permissions:
         return permissions.get(permission, None)
-    
+
     return None
+
 
 def _validate_source_permission(source: str, permission: str) -> bool:
     if source is None:
         return False
-    
-    resources = get_resource_permissions(permission)        
+
+    resources = get_resource_permissions(permission)
     if resources is not None:
         return any(r["resource_id"].lower() == source.lower() for r in resources)
-    
+
     return False

--- a/seta-api/seta_api/infrastructure/seta_jwt_manager.py
+++ b/seta-api/seta_api/infrastructure/seta_jwt_manager.py
@@ -1,44 +1,47 @@
-from calendar import timegm
-from json import JSONDecodeError
-from flask_jwt_extended import JWTManager
-from flask_jwt_extended.config import config as jwt_config
-from flask_jwt_extended.exceptions import CSRFError
-from flask_jwt_extended.exceptions import JWTDecodeError, NoAuthorizationError
-import requests
 from hmac import compare_digest
+from json import JSONDecodeError
+import requests
 from flask import Flask
 
+from flask_jwt_extended import JWTManager
+from flask_jwt_extended.config import config as jwt_config
+from flask_jwt_extended.exceptions import CSRFError, NoAuthorizationError
+
+
 class SetaJWTManager(JWTManager):
-    
-    token_info_url=None
+    token_info_url = None
     logger = None
     app: Flask = None
-    
+
     def init_app(self, app: Flask, add_context_processor: bool = False) -> None:
         super().init_app(app=app, add_context_processor=add_context_processor)
         self.token_info_url = app.config.get("JWT_TOKEN_INFO_URL")
         self.app = app
-    
-    """
-    Override _decode_jwt_from_config
-    """
+
     def _decode_jwt_from_config(
         self, encoded_token: str, csrf_value=None, allow_expired: bool = False
-    ) -> dict:              
-        
-        try:    
+    ) -> dict:
+        """Overrides _decode_jwt_from_config"""
+
+        try:
             if self.token_info_url is None:
                 return None
             headers = {"Content-Type": "application/json"}
-            json = {"token": encoded_token, "auth_area": ["resources"]}
-            
-            r = requests.post(url=self.token_info_url, json=json, headers=headers)
-            decoded_token = r.json()            
-            
-            #verification copied from flask_jwt_extended.tokens.py->_decode_token
+            json = {"token": encoded_token, "authorizationAreas": ["data-sources"]}
+
+            r = requests.post(
+                url=self.token_info_url, json=json, headers=headers, timeout=30
+            )
+            decoded_token = r.json()
+
+            # verification copied from flask_jwt_extended.tokens.py->_decode_token
             if jwt_config.identity_claim_key not in decoded_token:
-                raise JSONDecodeError("Missing claim: {}".format(jwt_config.identity_claim_key))
-            
+                raise JSONDecodeError(
+                    msg=f"Missing claim: {jwt_config.identity_claim_key}",
+                    doc=decoded_token,
+                    pos=0,
+                )
+
             if "type" not in decoded_token:
                 decoded_token["type"] = "access"
 
@@ -47,23 +50,23 @@ class SetaJWTManager(JWTManager):
 
             if "jti" not in decoded_token:
                 decoded_token["jti"] = None
-                
-            if csrf_value:                
+
+            if csrf_value:
                 if "csrf" not in decoded_token:
                     raise CSRFError("Missing claim: csrf")
                 if not compare_digest(decoded_token["csrf"], csrf_value):
                     raise CSRFError("CSRF double submit tokens do not match")
-            #end _decode_token verification
-            
+            # end _decode_token verification
+
             return decoded_token
         except ConnectionError as ce:
             self.app.logger.exception(ce)
-            raise NoAuthorizationError()
+            raise NoAuthorizationError() from ce
         except JSONDecodeError as je:
             self.app.logger.exception(je)
-            raise NoAuthorizationError()
+            raise NoAuthorizationError() from je
         except CSRFError:
             raise
         except Exception as e:
             self.app.logger.exception(e)
-            raise NoAuthorizationError()            
+            raise NoAuthorizationError() from e

--- a/seta-config/ui.conf
+++ b/seta-config/ui.conf
@@ -12,8 +12,11 @@ SCHEDULER_ENABLED = no
 #web application home url
 HOME_ROUTE = /
 
- #seta-api url for internal docker LAN calls
+#seta-api url for internal docker LAN calls
 PRIVATE_API_URL = http://seta-api:8081/seta-api-private/v1/
+
+#internal administration api for local docker LAN calls
+INTERNAL_ADMIN_API = http://seta-admin:8000/
 
 #disable swagger for internal apis
 DISABLE_SWAGGER_DOCUMENTATION = no

--- a/seta-ui/seta_flask_server/blueprints/admin/__init__.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/__init__.py
@@ -3,6 +3,8 @@ from flask import Blueprint, current_app
 
 from seta_flask_server.infrastructure.dto.authorizations import authorizations
 
+from seta_flask_server.infrastructure.dto.authorizations import authorizations
+
 from .change_requests import change_requests_ns
 from .orphans import orphans_ns
 from .stats import stats_ns

--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources/__init__.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources/__init__.py
@@ -1,0 +1,3 @@
+from .data_sources import *
+from .data_source import *
+from .indexes import *

--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources/data_source.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources/data_source.py
@@ -1,0 +1,173 @@
+from http import HTTPStatus
+
+from injector import inject
+
+from werkzeug.exceptions import BadRequest
+from flask import jsonify, current_app
+from flask_restx import Resource, abort
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from seta_flask_server.repository import interfaces
+
+from seta_flask_server.infrastructure.dto.payload_errors import PayloadErrors
+from seta_flask_server.blueprints.admin.logic import user_logic, data_sources_logic
+from seta_flask_server.blueprints.admin.models import data_source_dto as dto
+
+from .ns import data_sources_ns
+
+
+@data_sources_ns.route(
+    "/<string:data_source_id>", endpoint="admin_data_source", methods=["PUT"]
+)
+@data_sources_ns.param("data_source_id", "Data source identifier")
+class DataSourceResource(Resource):
+    """Handles HTTP requests to URL: /admin/data-sources/{data_source_id}."""
+
+    @inject
+    def __init__(
+        self,
+        users_broker: interfaces.IUsersBroker,
+        data_sources_broker: interfaces.IDataSourcesBroker,
+        *args,
+        api=None,
+        **kwargs,
+    ):
+        self.users_broker = users_broker
+        self.data_sources_broker = data_sources_broker
+
+        super().__init__(api, *args, **kwargs)
+
+    @data_sources_ns.doc(
+        description="Update data source",
+        responses={
+            int(HTTPStatus.OK): "Data source updated.",
+            int(HTTPStatus.BAD_REQUEST): "Errors in request payload",
+            int(HTTPStatus.FORBIDDEN): "Insufficient rights",
+            int(HTTPStatus.NOT_FOUND): "Data source not found.",
+        },
+        security="CSRF",
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.OK), "", dto.response_dto.response_message_model
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.BAD_REQUEST), "", dto.response_dto.error_model
+    )
+    @data_sources_ns.expect(dto.update_data_source_model)
+    @jwt_required()
+    def put(self, data_source_id: str):
+        """
+        Updates a data source, available to sysadmins
+
+        Permissions: "Administrator" role
+        """
+
+        identity = get_jwt_identity()
+        auth_id = identity["user_id"]
+
+        user = self.users_broker.get_user_by_id(auth_id, load_scopes=False)
+        if not user_logic.is_admin(user):
+            abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
+
+        data_source = self.data_sources_broker.get_by_id(data_source_id)
+        if data_source is None:
+            abort(HTTPStatus.NOT_FOUND, message="Data source not found.")
+
+        try:
+            update_data_source = data_sources_logic.build_update_data_source(
+                broker=self.data_sources_broker,
+                payload=data_sources_ns.payload,
+                data_source=data_source,
+            )
+
+            self.data_sources_broker.update(update_data_source)
+        except PayloadErrors as pe:
+            e = BadRequest()
+            e.data = pe.response_data
+            raise e  # pylint: disable=raise-missing-from
+        except Exception:
+            current_app.logger.exception("DataSourceResource->put")
+            abort()
+
+        return jsonify(status="success", message="Data source updated.")
+
+
+@data_sources_ns.route(
+    "/<string:data_source_id>/scopes",
+    endpoint="admin_data_source_scopes",
+    methods=["POST"],
+)
+@data_sources_ns.param("data_source_id", "Data source identifier")
+class DataSourceScopesResource(Resource):
+    """Handles HTTP requests to URL: /admin/data-sources/{data_source_id}/scopes."""
+
+    @inject
+    def __init__(
+        self,
+        users_broker: interfaces.IUsersBroker,
+        data_sources_broker: interfaces.IDataSourcesBroker,
+        data_source_scopes_broker: interfaces.IDataSourceScopesBroker,
+        *args,
+        api=None,
+        **kwargs,
+    ):
+        self.users_broker = users_broker
+        self.data_sources_broker = data_sources_broker
+        self.data_source_scopes_broker = data_source_scopes_broker
+
+        super().__init__(api, *args, **kwargs)
+
+    @data_sources_ns.doc(
+        description="Set data source scopes",
+        responses={
+            int(HTTPStatus.OK): "Data source scopes set.",
+            int(HTTPStatus.BAD_REQUEST): "Errors in request payload",
+            int(HTTPStatus.FORBIDDEN): "Insufficient rights",
+            int(HTTPStatus.NOT_FOUND): "Data source not found.",
+        },
+        security="CSRF",
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.OK), "", dto.response_dto.response_message_model
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.BAD_REQUEST), "", dto.response_dto.error_model
+    )
+    @data_sources_ns.expect(dto.replace_data_source_scopes_model)
+    @jwt_required()
+    def post(self, data_source_id: str):
+        """
+        Set scopes for a data source, available to sysadmins
+
+        Permissions: "Administrator" role
+        """
+
+        identity = get_jwt_identity()
+        auth_id = identity["user_id"]
+
+        user = self.users_broker.get_user_by_id(auth_id, load_scopes=False)
+        if not user_logic.is_admin(user):
+            abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
+
+        if not self.data_sources_broker.identifier_exists(
+            data_source_id=data_source_id
+        ):
+            abort(HTTPStatus.NOT_FOUND, message="Data source not found.")
+
+        try:
+            scopes = data_sources_logic.build_data_source_scopes(
+                data_source_id=data_source_id, payload=data_sources_ns.payload
+            )
+
+            self.data_source_scopes_broker.replace_for_data_source(
+                data_source_id=data_source_id, scopes=scopes
+            )
+        except PayloadErrors as pe:
+            e = BadRequest()
+            e.data = pe.response_data
+            raise e  # pylint: disable=raise-missing-from
+        except Exception:
+            current_app.logger.exception("DataSourcesResource->post")
+            abort()
+
+        return jsonify(status="success", message="Data source scopes set.")

--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources/data_sources.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources/data_sources.py
@@ -1,21 +1,20 @@
 from http import HTTPStatus
+
+from requests import HTTPError
 from injector import inject
 
 from werkzeug.exceptions import BadRequest
 from flask import jsonify, current_app
-from flask_restx import Namespace, Resource, abort
+from flask_restx import Resource, abort
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from seta_flask_server.repository import interfaces
 
 from seta_flask_server.infrastructure.dto.payload_errors import PayloadErrors
 from seta_flask_server.blueprints.admin.logic import user_logic, data_sources_logic
-from .models import data_source_dto as dto
+from seta_flask_server.blueprints.admin.models import data_source_dto as dto
 
-data_sources_ns = Namespace(
-    "Data Sources", description="Admin data sources", validate=False
-)
-data_sources_ns.models.update(dto.ns_models)
+from .ns import data_sources_ns
 
 
 @data_sources_ns.route("", endpoint="admin_data_sources", methods=["GET", "POST"])
@@ -27,12 +26,16 @@ class DataSourcesResource(Resource):
         self,
         users_broker: interfaces.IUsersBroker,
         data_sources_broker: interfaces.IDataSourcesBroker,
+        search_index_broker: interfaces.ISearchIndexesBroker,
+        data_source_scopes_broker: interfaces.IDataSourceScopesBroker,
         *args,
         api=None,
         **kwargs,
     ):
         self.users_broker = users_broker
         self.data_sources_broker = data_sources_broker
+        self.search_index_broker = search_index_broker
+        self.data_source_scopes_broker = data_source_scopes_broker
 
         super().__init__(api, *args, **kwargs)
 
@@ -62,12 +65,18 @@ class DataSourcesResource(Resource):
 
         # verify scope
         user = self.users_broker.get_user_by_id(auth_id)
-        if not user_logic.can_approve_resource_cr(user):
+        if not user_logic.is_admin(user):
             abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
 
         data_sources = self.data_sources_broker.get_all(active_only=False)
         data_sources_logic.load_data_sources_creators(
             data_sources=data_sources, users_broker=self.users_broker
+        )
+
+        data_sources_logic.load_data_sources_scopes(
+            data_sources=data_sources,
+            scopes_broker=self.data_source_scopes_broker,
+            users_broker=self.users_broker,
         )
 
         return data_sources
@@ -109,90 +118,34 @@ class DataSourcesResource(Resource):
             )
             data_source.creator_id = auth_id
 
+            data_sources_logic.create_index_model(
+                index=data_source.search_index,
+                broker=self.search_index_broker,
+                ignore_exists=True,
+            )
+
             self.data_sources_broker.create(data_source)
         except PayloadErrors as pe:
             e = BadRequest()
             e.data = pe.response_data
             raise e  # pylint: disable=raise-missing-from
+        except HTTPError as e:
+            if e.response.status_code == int(HTTPStatus.CONFLICT):
+                current_app.logger.info(
+                    "The index '%s' already exists in Search engine.",
+                    data_source.index_name,
+                )
+            else:
+                current_app.logger.debug(str(e))
+                abort(
+                    code=HTTPStatus(e.response.status_code),
+                    message="Error on search index creation.",
+                )
         except Exception:
-            current_app.logger.exception("RollingIndexes->post")
+            current_app.logger.exception("DataSourcesResource->post")
             abort()
 
         response = jsonify(status="success", message="Data source created.")
         response.status_code = HTTPStatus.CREATED
 
         return response
-
-
-@data_sources_ns.route(
-    "/<string:data_source_id>", endpoint="admin_data_source", methods=["PUT"]
-)
-@data_sources_ns.param("data_source_id", "Data source identifier")
-@data_sources_ns.response(int(HTTPStatus.BAD_REQUEST), "", dto.response_dto.error_model)
-class DataSourceResource(Resource):
-    """Handles HTTP requests to URL: /admin/data-sources/{data_source_id}."""
-
-    @inject
-    def __init__(
-        self,
-        users_broker: interfaces.IUsersBroker,
-        data_sources_broker: interfaces.IDataSourcesBroker,
-        *args,
-        api=None,
-        **kwargs,
-    ):
-        self.users_broker = users_broker
-        self.data_sources_broker = data_sources_broker
-
-        super().__init__(api, *args, **kwargs)
-
-    @data_sources_ns.doc(
-        description="Update data source",
-        responses={
-            int(HTTPStatus.OK): "Data source updated.",
-            int(HTTPStatus.BAD_REQUEST): "Errors in request payload",
-            int(HTTPStatus.FORBIDDEN): "Insufficient rights",
-            int(HTTPStatus.NOT_FOUND): "Data source not found.",
-        },
-        security="CSRF",
-    )
-    @data_sources_ns.response(
-        int(HTTPStatus.OK), "", dto.response_dto.response_message_model
-    )
-    @data_sources_ns.expect(dto.update_data_source_model)
-    @jwt_required()
-    def put(self, data_source_id: str):
-        """
-        Updates a data source, available to sysadmins
-
-        Permissions: "Administrator" role
-        """
-
-        identity = get_jwt_identity()
-        auth_id = identity["user_id"]
-
-        user = self.users_broker.get_user_by_id(auth_id, load_scopes=False)
-        if not user_logic.is_admin(user):
-            abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
-
-        data_source = self.data_sources_broker.get_by_id(data_source_id)
-        if data_source is None:
-            abort(HTTPStatus.NOT_FOUND, message="Data source not found.")
-
-        try:
-            update_data_source = data_sources_logic.build_update_data_source(
-                broker=self.data_sources_broker,
-                payload=data_sources_ns.payload,
-                data_source=data_source,
-            )
-
-            self.data_sources_broker.update(update_data_source)
-        except PayloadErrors as pe:
-            e = BadRequest()
-            e.data = pe.response_data
-            raise e  # pylint: disable=raise-missing-from
-        except Exception:
-            current_app.logger.exception("DataSourceResource->put")
-            abort()
-
-        return jsonify(status="success", message="Data source updated.")

--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources/indexes.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources/indexes.py
@@ -1,0 +1,121 @@
+from http import HTTPStatus
+from injector import inject
+
+from werkzeug.exceptions import BadRequest
+from flask import jsonify, current_app
+from flask_restx import Resource, abort
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from seta_flask_server.repository import interfaces
+
+from seta_flask_server.infrastructure.dto.payload_errors import PayloadErrors
+from seta_flask_server.blueprints.admin.logic import user_logic, data_sources_logic
+from seta_flask_server.blueprints.admin.models import data_source_dto as dto
+
+from .ns import data_sources_ns
+
+
+@data_sources_ns.route("/indexes", endpoint="admin_indexes", methods=["GET", "POST"])
+class SearchIndexesResource(Resource):
+    """Handles HTTP requests to URL: /admin/data-sources/indexes."""
+
+    @inject
+    def __init__(
+        self,
+        users_broker: interfaces.IUsersBroker,
+        search_index_broker: interfaces.ISearchIndexesBroker,
+        *args,
+        api=None,
+        **kwargs,
+    ):
+        self.users_broker = users_broker
+        self.search_index_broker = search_index_broker
+
+        super().__init__(api, *args, **kwargs)
+
+    @data_sources_ns.doc(
+        description="Get all indexes",
+        responses={
+            int(HTTPStatus.OK): "Retrieved indexes.",
+            int(
+                HTTPStatus.FORBIDDEN
+            ): "Insufficient rights, role 'Administrator' required",
+        },
+        security="CSRF",
+    )
+    @data_sources_ns.marshal_list_with(
+        dto.view_search_index_model, mask="*", skip_none=True
+    )
+    @jwt_required()
+    def get(self):
+        """
+        Retrieve all indexes, available to sysadmin,
+
+        Permissions: "Administrator" role
+        """
+
+        identity = get_jwt_identity()
+        auth_id = identity["user_id"]
+
+        # verify scope
+        user = self.users_broker.get_user_by_id(auth_id)
+        if not user_logic.is_admin(user):
+            abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
+
+        return self.search_index_broker.get_all()
+
+    @data_sources_ns.doc(
+        description="Create index.",
+        responses={
+            int(HTTPStatus.CREATED): "Created index.",
+            int(HTTPStatus.BAD_REQUEST): "Errors in request payload",
+            int(HTTPStatus.FORBIDDEN): "Insufficient rights",
+        },
+        security="CSRF",
+    )
+    @data_sources_ns.expect(dto.new_search_index_model)
+    @data_sources_ns.response(
+        int(HTTPStatus.CREATED), "", dto.response_dto.response_message_model
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.BAD_REQUEST), "Bad payload", dto.response_dto.error_model
+    )
+    @data_sources_ns.response(
+        int(HTTPStatus.CONFLICT),
+        "Search engine already contains this index",
+        dto.response_dto.error_model,
+    )
+    @jwt_required()
+    def post(self):
+        """Create a new index, available to sysadmins.
+
+        Permissions: "Administrator" role
+        """
+
+        identity = get_jwt_identity()
+        auth_id = identity["user_id"]
+
+        user = self.users_broker.get_user_by_id(auth_id, load_scopes=False)
+        if not user_logic.is_admin(user):
+            abort(HTTPStatus.FORBIDDEN, "Insufficient rights.")
+
+        try:
+            index = data_sources_logic.build_index_model(
+                payload=data_sources_ns.payload
+            )
+
+            data_sources_logic.create_index_model(
+                index=index, broker=self.search_index_broker
+            )
+        except PayloadErrors as pe:
+            e = BadRequest()
+            e.data = pe.response_data
+            raise e  # pylint: disable=raise-missing-from
+        except Exception:
+            current_app.logger.exception("SearchIndexesResource->post")
+            abort()
+
+        response = jsonify(status="success", message="Index created.")
+        response.status_code = HTTPStatus.CREATED
+
+        return response

--- a/seta-ui/seta_flask_server/blueprints/admin/data_sources/ns.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/data_sources/ns.py
@@ -1,0 +1,7 @@
+from flask_restx import Namespace
+from seta_flask_server.blueprints.admin.models import data_source_dto as dto
+
+data_sources_ns = Namespace(
+    "Data Sources", description="Admin data sources", validate=False
+)
+data_sources_ns.models.update(dto.ns_models)

--- a/seta-ui/seta_flask_server/blueprints/admin/logic/data_sources_logic.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/logic/data_sources_logic.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+from requests import HTTPError
 from pydantic import ValidationError
 
 from flask import current_app
@@ -6,6 +8,7 @@ from seta_flask_server.repository import interfaces
 from seta_flask_server.repository import models
 
 from seta_flask_server.infrastructure.dto.payload_errors import PayloadErrors
+from seta_flask_server.infrastructure.clients import admin_client
 
 
 def load_data_sources_creators(
@@ -29,6 +32,37 @@ def load_data_sources_creators(
             data_source.creator = creator.user_info
 
 
+def load_data_sources_scopes(
+    data_sources: list[models.DataSourceModel],
+    scopes_broker: interfaces.IDataSourceScopesBroker,
+    users_broker: interfaces.IUsersBroker,
+):
+    """Load data sources scopes from database."""
+
+    scopes = scopes_broker.get_all()
+
+    for data_source in data_sources:
+        ds_scopes = list(
+            filter(
+                lambda s, id=data_source.data_source_id: s.data_source_id == id, scopes
+            )
+        )
+
+        if ds_scopes:
+            for scope in ds_scopes:
+                if data_source.creator_id is not None:
+                    user = users_broker.get_user_by_id(scope.user_id, load_scopes=False)
+
+                    if user is None:
+                        scope.user = models.UserInfo(
+                            user_id=scope.user_id, full_name="Unknown"
+                        )
+                    else:
+                        scope.user = user.user_info
+
+            data_source.scopes = ds_scopes
+
+
 def build_new_data_source(
     payload: dict, broker: interfaces.IDataSourcesBroker
 ) -> models.DataSourceModel:
@@ -39,6 +73,10 @@ def build_new_data_source(
 
     try:
         data_source = models.DataSourceModel(**payload)
+
+        data_source.search_index = models.SearchIndexModel(
+            name=payload["index"],
+        )
     except ValidationError as e:
         has_errors = True
         current_app.logger.debug(e)
@@ -104,3 +142,91 @@ def build_update_data_source(
         )
 
     return update_data_source
+
+
+def build_data_source_scopes(
+    data_source_id: str, payload: dict
+) -> list[models.DataSourceScopeModel]:
+    """Build the list of scopes from payload."""
+
+    if not payload or not payload.get("scopes"):
+        return None
+
+    scopes = []
+    has_errors = False
+    errors = {}
+
+    scopes_payload = payload["scopes"]
+
+    try:
+        for scope in scopes_payload:
+            scope["data_source_id"] = data_source_id
+            scopes.append(models.DataSourceScopeModel(**scope))
+
+    except ValidationError as e:
+        has_errors = True
+        current_app.logger.debug(e)
+
+        for err in e.errors():
+            errors[err["loc"][0]] = err["msg"]
+
+    if has_errors:
+        raise PayloadErrors(
+            message="Errors encountered in data source payload", errors=errors
+        )
+
+    return scopes
+
+
+def build_index_model(payload: dict) -> models.SearchIndexModel:
+    """Build search index object for database insert."""
+
+    has_errors = False
+    errors = {}
+
+    try:
+        index = models.SearchIndexModel(**payload)
+    except ValidationError as e:
+        has_errors = True
+        current_app.logger.debug(e)
+
+        for err in e.errors():
+            errors[err["loc"][0]] = err["msg"]
+
+    if has_errors:
+        raise PayloadErrors(message="Errors encountered in the payload", errors=errors)
+
+    return index
+
+
+def create_index_model(
+    index: models.SearchIndexModel,
+    broker: interfaces.ISearchIndexesBroker,
+    ignore_exists=False,
+):
+    """Creates index in Search engine and store in in database.
+
+    Args:
+       index: search index object.
+       broker: repository broker.
+       ignore_exists: Do nothing if the index already exists in the database.
+    """
+
+    if broker.index_name_exists(index.index_name):
+        if ignore_exists:
+            return
+
+        msg = "Index name already exists."
+        raise PayloadErrors(msg, errors={"name": msg})
+
+    try:
+        client = admin_client.AdminIndexesClient()
+        client.create(index.index_name)
+    except HTTPError as e:
+        #! ignore error if index already exists in the Search engine
+        if e.response.status_code == int(HTTPStatus.CONFLICT):
+            current_app.logger.info(
+                "The index '%s' already exists in Search engine.", index.index_name
+            )
+
+    broker.create(index)

--- a/seta-ui/seta_flask_server/blueprints/data_sources/data_source.py
+++ b/seta-ui/seta_flask_server/blueprints/data_sources/data_source.py
@@ -48,7 +48,7 @@ class DataSourcesResource(Resource):
 
         for data_source in data_sources:
             ds_dict = data_source.to_dict(
-                exclude={"creator", "creator_id", "modified_at", "status"}
+                exclude={"creator", "creator_id", "modified_at", "status", "index_name"}
             )
 
             ds_dict["searchable"] = (

--- a/seta-ui/seta_flask_server/config.py
+++ b/seta-ui/seta_flask_server/config.py
@@ -45,6 +45,7 @@ class Config:
         Config.AUTH_CAS_URL = config_section.get("AUTH_CAS_URL")
         Config.HOME_ROUTE = config_section.get("HOME_ROUTE", fallback="/")
         Config.PRIVATE_API_URL = config_section["PRIVATE_API_URL"]
+        Config.INTERNAL_ADMIN_API = config_section["INTERNAL_ADMIN_API"]
 
         Config.SCHEDULER_ENABLED = config_section.getboolean(
             "SCHEDULER_ENABLED", fallback=False

--- a/seta-ui/seta_flask_server/dependency.py
+++ b/seta-ui/seta_flask_server/dependency.py
@@ -51,6 +51,12 @@ class MongoDbClientModule(injector.Module):
         binder.bind(interfaces.IDataSourcesBroker, to=implementation.DataSourcesBroker)
         binder.bind(interfaces.IAnnotationsBroker, to=implementation.AnnotationsBroker)
         binder.bind(
+            interfaces.IDataSourceScopesBroker, to=implementation.DataSourceScopesBroker
+        )
+        binder.bind(
+            interfaces.ISearchIndexesBroker, to=implementation.SearchIndexesBroker
+        )
+        binder.bind(
             interfaces.IUserProfileUnsearchables,
             to=implementation.UserProfileUnsearchables,
         )

--- a/seta-ui/seta_flask_server/infrastructure/clients/admin_client.py
+++ b/seta-ui/seta_flask_server/infrastructure/clients/admin_client.py
@@ -1,0 +1,40 @@
+import json
+import requests
+
+from flask import current_app
+from seta_flask_server.infrastructure import helpers
+
+
+class AdminClient:
+    def __init__(self) -> None:
+        self.api_root = current_app.config["INTERNAL_ADMIN_API"]
+        self.headers = {"Content-Type": "application/json"}
+
+
+class AdminIndexesClient(AdminClient):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.url = helpers.urljoin_segments(self.api_root, "indexes")
+
+    def create(self, index_name: str):
+        """Creates a new index in Search engine."""
+
+        payload = {"name": index_name}
+        data = json.dumps(payload)
+
+        result = requests.post(
+            url=self.url, data=data, headers=self.headers, timeout=30
+        )
+        result.raise_for_status()
+
+    def delete(self, index_name: str) -> None:
+        """Delete search index"""
+
+        payload = {"name": index_name}
+        data = json.dumps(payload)
+
+        result = requests.delete(
+            url=self.url, data=data, headers=self.headers, timeout=30
+        )
+        result.raise_for_status()

--- a/seta-ui/seta_flask_server/infrastructure/constants.py
+++ b/seta-ui/seta_flask_server/infrastructure/constants.py
@@ -149,8 +149,8 @@ class StatsTypeConstants:
 
 
 class AuthorizedArea:
-    Resources = "resources"
-    List = [Resources]
+    DataSources = "data-sources"
+    List = [DataSources]
 
 
 class UserType:

--- a/seta-ui/seta_flask_server/repository/interfaces/__init__.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/__init__.py
@@ -20,4 +20,6 @@ from .rolling_index_broker import IRollingIndexBroker
 
 from .data_sources_broker import IDataSourcesBroker
 from .annotations_broker import IAnnotationsBroker
+from .data_source_scopes_broker import IDataSourceScopesBroker
+from .search_indexes_broker import ISearchIndexesBroker
 from .user_profile_unsearchables import IUserProfileUnsearchables

--- a/seta-ui/seta_flask_server/repository/interfaces/data_source_scopes_broker.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/data_source_scopes_broker.py
@@ -1,0 +1,26 @@
+from interface import Interface
+from seta_flask_server.repository.models import DataSourceScopeModel
+
+
+class IDataSourceScopesBroker(Interface):
+    def get_all(self) -> list[DataSourceScopeModel]:
+        """Retrieves all scopes."""
+
+        pass
+
+    def get_by_data_source_id(self, data_source_id: str) -> list[DataSourceScopeModel]:
+        """Retrieves all scopes for a data source."""
+
+        pass
+
+    def get_by_user_id(self, user_id: str) -> list[DataSourceScopeModel]:
+        """Retrieves all data source scopes for a user."""
+
+        pass
+
+    def replace_for_data_source(
+        self, data_source_id: str, scopes: list[DataSourceScopeModel]
+    ):
+        """Replace all scopes for a data source."""
+
+        pass

--- a/seta-ui/seta_flask_server/repository/interfaces/search_indexes_broker.py
+++ b/seta-ui/seta_flask_server/repository/interfaces/search_indexes_broker.py
@@ -1,0 +1,19 @@
+from interface import Interface
+from seta_flask_server.repository.models import SearchIndexModel
+
+
+class ISearchIndexesBroker(Interface):
+    def create(self, model: SearchIndexModel) -> None:
+        """Inserts search index model in database."""
+
+        pass
+
+    def get_all(self) -> list[SearchIndexModel]:
+        """Retrieves all indexes."""
+
+        pass
+
+    def index_name_exists(self, index_name: str) -> bool:
+        """Checks existing index name."""
+
+        pass

--- a/seta-ui/seta_flask_server/repository/models/__init__.py
+++ b/seta-ui/seta_flask_server/repository/models/__init__.py
@@ -25,6 +25,12 @@ from .account_info import AccountInfo
 from .catalogue_field import CatalogueField
 from .rolling_index import StorageLimits, StorageIndex, RollingIndex
 
-from .data_source import DataSourceContactModel, DataSourceModel
+from .data_source import (
+    DataSourceContactModel,
+    DataSourceModel,
+    SearchIndexModel,
+    DataSourceScopeModel,
+    DataSourceScopeEnum,
+)
 from .annotation import AnnotationModel
 from .profile import UnsearchablesModel

--- a/seta-ui/seta_flask_server/repository/models/data_source/__init__.py
+++ b/seta-ui/seta_flask_server/repository/models/data_source/__init__.py
@@ -1,0 +1,3 @@
+from .data_source import DataSourceContactModel, DataSourceModel
+from .search_index import SearchIndexModel
+from .data_source_scope import DataSourceScopeModel, DataSourceScopeEnum

--- a/seta-ui/seta_flask_server/repository/models/data_source/data_source.py
+++ b/seta-ui/seta_flask_server/repository/models/data_source/data_source.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 from typing import Optional
+
 from pydantic import BaseModel, Field, EmailStr, HttpUrl, field_serializer
 
 from seta_flask_server.infrastructure.constants import DataSourceStatusConstants
 
-from .user_info import UserInfo
+from .search_index import SearchIndexModel
+from .data_source_scope import DataSourceScopeModel
+from ..user_info import UserInfo
 
 
 class DataSourceContactModel(BaseModel):
@@ -23,6 +26,7 @@ class DataSourceModel(BaseModel):
     data_source_id: str = Field(min_length=3, max_length=100, validation_alias="id")
     title: str = Field(min_length=3, max_length=200)
     description: str = Field(min_length=5, max_length=5000)
+    index_name: str = Field(validation_alias="index")
     organisation: Optional[str] = None
     theme: Optional[str] = None
     status: DataSourceStatusConstants = DataSourceStatusConstants.ACTIVE
@@ -31,16 +35,12 @@ class DataSourceModel(BaseModel):
     created_at: Optional[datetime] = None
     modified_at: Optional[datetime] = None
 
-    creator: Optional[UserInfo] = None
+    creator: Optional[UserInfo] = Field(default=None, exclude=True)
+    search_index: Optional[SearchIndexModel] = Field(default=None, exclude=True)
+    scopes: Optional[list[DataSourceScopeModel]] = Field(default=None, exclude=True)
 
     def to_dict(self, exclude: set[str] = None):
         """Convert model to dictionary."""
-
-        if exclude is None:
-            exclude = {"creator"}
-
-        if not "creator" in exclude:
-            exclude.add("creator")
 
         json = self.model_dump(exclude=exclude)
         return json

--- a/seta-ui/seta_flask_server/repository/models/data_source/data_source_scope.py
+++ b/seta-ui/seta_flask_server/repository/models/data_source/data_source_scope.py
@@ -1,0 +1,16 @@
+from enum import Enum
+from pydantic import BaseModel, Field
+
+from ..user_info import UserInfo
+
+
+class DataSourceScopeEnum(str, Enum):
+    DATA_OWNER = "/seta/data-source/owner"
+
+
+class DataSourceScopeModel(BaseModel):
+    data_source_id: str
+    user_id: str
+    scope: DataSourceScopeEnum
+
+    user: UserInfo | None = Field(default=None, exclude=True)

--- a/seta-ui/seta_flask_server/repository/models/data_source/search_index.py
+++ b/seta-ui/seta_flask_server/repository/models/data_source/search_index.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class SearchIndexModel(BaseModel):
+    index_name: str = Field(
+        min_length=3,
+        max_length=200,
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$",
+        validation_alias="name",
+    )
+    created_at: datetime | None = None
+    default: bool = False
+
+    def model_post_init(self, __context) -> None:
+        self.index_name = self.index_name.lower()

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/__init__.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/__init__.py
@@ -19,6 +19,6 @@ from .db_users_query_broker import UsersQueryBroker
 from .db_external_provider_broker import ExternalProviderBroker
 from .db_rolling_index_broker import RollingIndexBroker
 
-from .db_data_sources_broker import DataSourcesBroker
+from .data_sources import DataSourcesBroker, DataSourceScopesBroker, SearchIndexesBroker
 from .db_annotations_broker import AnnotationsBroker
 from .profile import UserProfileUnsearchables

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/__init__.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/__init__.py
@@ -1,0 +1,3 @@
+from .db_data_sources_broker import DataSourcesBroker
+from .db_search_indexes_broker import SearchIndexesBroker
+from .db_data_source_scopes_broker import DataSourceScopesBroker

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_data_source_scopes_broker.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_data_source_scopes_broker.py
@@ -1,0 +1,57 @@
+from interface import implements
+from injector import inject
+
+from seta_flask_server.repository.interfaces import IDbConfig, IDataSourceScopesBroker
+from seta_flask_server.repository.models import DataSourceScopeModel
+
+
+class DataSourceScopesBroker(implements(IDataSourceScopesBroker)):
+    @inject
+    def __init__(self, config: IDbConfig) -> None:
+        self.db = config.get_db()
+        self.collection = self.db["data-source-scopes"]
+
+    def get_all(self) -> list[DataSourceScopeModel]:
+        """Retrieves all scopes."""
+
+        scopes = self.collection.find()
+
+        return [_data_source_scope_from_db_json(scope) for scope in scopes]
+
+    def get_by_data_source_id(self, data_source_id: str) -> list[DataSourceScopeModel]:
+        """Retrieves all scopes for a data source."""
+
+        scopes = self.collection.find({"data_source_id": data_source_id})
+
+        return [_data_source_scope_from_db_json(scope) for scope in scopes]
+
+    def get_by_user_id(self, user_id: str) -> list[DataSourceScopeModel]:
+        """Retrieves all data source scopes for a user."""
+
+        scopes = self.collection.find({"user_id": user_id})
+
+        return [_data_source_scope_from_db_json(scope) for scope in scopes]
+
+    def replace_for_data_source(
+        self, data_source_id: str, scopes: list[DataSourceScopeModel]
+    ):
+        """Replace all scopes for a data source."""
+
+        scope_list = [s.model_dump() for s in scopes]
+
+        with self.db.client.start_session(causal_consistency=True) as session:
+            # delete existing system scopes
+            self.collection.delete_many(
+                {"data_source_id": data_source_id}, session=session
+            )
+            # insert new scopes
+            if scope_list:
+                self.collection.insert_many(scope_list, session=session)
+
+
+def _data_source_scope_from_db_json(json_dict: dict) -> DataSourceScopeModel:
+    return DataSourceScopeModel.model_construct(
+        data_source_id=json_dict["data_source_id"],
+        user_id=json_dict["user_id"],
+        scope=json_dict["scope"],
+    )

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_data_sources_broker.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_data_sources_broker.py
@@ -25,7 +25,7 @@ class DataSourcesBroker(implements(IDataSourcesBroker)):
     def update(self, model: DataSourceModel) -> None:
         model.modified_at = datetime.now(tz=pytz.utc)
 
-        json = model.to_dict(exclude={"created_at", "creator_id"})
+        json = model.to_dict(exclude={"created_at", "creator_id", "index_name"})
         set_json = {"$set": json}
 
         self.collection.update_one({"data_source_id": model.data_source_id}, set_json)
@@ -82,6 +82,7 @@ def _data_source_from_db_json(json_dict: dict) -> DataSourceModel:
         data_source_id=json_dict["data_source_id"],
         title=json_dict["title"],
         description=json_dict["description"],
+        index_name=json_dict["index_name"],
         organisation=json_dict.get("organisation"),
         theme=json_dict.get("theme"),
         status=json_dict["status"],

--- a/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_search_indexes_broker.py
+++ b/seta-ui/seta_flask_server/repository/mongo_implementation/data_sources/db_search_indexes_broker.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+import pytz
+from interface import implements
+from injector import inject
+
+from seta_flask_server.repository.interfaces import IDbConfig, ISearchIndexesBroker
+from seta_flask_server.repository.models import SearchIndexModel
+
+
+class SearchIndexesBroker(implements(ISearchIndexesBroker)):
+    @inject
+    def __init__(self, config: IDbConfig) -> None:
+        self.db = config.get_db()
+        self.collection = self.db["search-indexes"]
+
+    def create(self, model: SearchIndexModel) -> None:
+        """Inserts search index model in database."""
+
+        if not self.index_name_exists(model.index_name):
+            model.created_at = datetime.now(tz=pytz.utc)
+
+            model_json = model.model_dump()
+            self.collection.insert_one(model_json)
+
+    def get_all(self) -> list[SearchIndexModel]:
+        """Retrieves all indexes."""
+
+        indexes = self.collection.find()
+        return [_search_index_from_db_json(index) for index in indexes]
+
+    def index_name_exists(self, index_name: str) -> bool:
+        """Checks existing index name."""
+
+        if index_name is None:
+            return False
+
+        exists_count = self.collection.count_documents(
+            {"index_name": index_name.lower()}
+        )
+        return exists_count > 0
+
+
+def _search_index_from_db_json(json_dict: dict) -> SearchIndexModel:
+    return SearchIndexModel.model_construct(
+        index_name=json_dict["index_name"],
+        created_at=json_dict.get("created_at", None),
+        default=json_dict.get("default", False),
+    )


### PR DESCRIPTION
Sysadmin api: [http://localhost/seta-ui/api/v1/admin/doc](http://localhost/seta-ui/api/v1/admin/doc), Data Sources namespace.

**Once this PR merged, your old resource queries and add/delete permissions will not work anymore!**

Create data source through sysadmin api:
* "id": "**cordis**", # **current resource with data in OpenSearch**
* "index": "**seta-public-000001**" # **current index in OpenSearch**, check seta-config/api.conf

```
POST http://localhost/seta-ui/api/v1/admin/data-sources
{
  "title": "Cordis",
  "description": "Cordis",
  "id": "cordis",
  "index": "seta-public-000001"
}
```

After data source creation, your should be able to query the data from OpenSearch, _cordis_ source.
In order to add/delete documents, add data owner scope for your user and data source:
* use the above data source identifier in path (or in Swagger UI)
* replace user_id with the one you'll find in mongodb or, easier, in user profile UI - [http://localhost/profile](http://localhost/profile)

```
POST http://localhost/seta-ui/api/v1/admin/data-sources/**cordis**/scopes
{
  "scopes": [
    {
      "user_id": "4YemHXJNg3HtV4bjpZ",
      "scope": "/seta/data-source/owner"
    }
  ]
}
```

Repeat the above steps for other existing OpenSearch data sources.