### PR TITLE
Move internal admin api to /set-admin

### DIFF
--- a/seta-admin/main.py
+++ b/seta-admin/main.py
@@ -16,7 +16,9 @@ def create_app() -> FastAPI():
     # get root logger
     logger = logging.getLogger(__name__)
 
-    app = FastAPI(root_path="/admin", title="Internal Administration", version="0.0.1")
+    app = FastAPI(
+        root_path="/seta-admin", title="Internal Administration", version="0.0.1"
+    )
 
     @app.middleware("http")
     async def log_requests(request: Request, call_next):

--- a/seta-nginx/project_dev.conf
+++ b/seta-nginx/project_dev.conf
@@ -119,7 +119,7 @@ server {
         }
 
         #for development only
-        location /admin/ {
+        location /seta-admin/ {
                 #access_log off;
                 #allow 172.18.0.0/16;   # This is local docker IP range
                 #deny all;

--- a/seta-ui/seta_flask_server/blueprints/admin/__init__.py
+++ b/seta-ui/seta_flask_server/blueprints/admin/__init__.py
@@ -3,8 +3,6 @@ from flask import Blueprint, current_app
 
 from seta_flask_server.infrastructure.dto.authorizations import authorizations
 
-from seta_flask_server.infrastructure.dto.authorizations import authorizations
-
 from .change_requests import change_requests_ns
 from .orphans import orphans_ns
 from .stats import stats_ns

--- a/seta-ui/seta_flask_server/factory.py
+++ b/seta-ui/seta_flask_server/factory.py
@@ -128,7 +128,7 @@ def register_blueprints(app):
     app.register_blueprint(communities_bp_v1, url_prefix=api_root_v1)
 
     app.register_blueprint(catalogue_bp_v1, url_prefix=api_root_v1)
-    
+
     app.register_blueprint(notifications_bp_v1, url_prefix=api_root_v1)
 
     app.register_blueprint(data_sources_bp_v1, url_prefix=api_root_v1)


### PR DESCRIPTION
Fix colliding url for admin UI & internal admin service in **development**.
Swagger docs moved to [http://localhost/seta-admin/docs](http://localhost/seta-admin/docs) url.