### PR TITLE
[seta-react] Split Search & NLP APIs

### DIFF
--- a/seta-react/src/api/embeddings/embedding-info.ts
+++ b/seta-react/src/api/embeddings/embedding-info.ts
@@ -76,7 +76,7 @@ export const getFilesEmbeddingInfo = async (
 
     reportProgress(0, `Extracting text from ${file.name} ...`)
 
-    const { text } = await getTextFromFile(file, config)
+    const text = await getTextFromFile(file, config)
 
     const normalizedText = text
       .split('\n')

--- a/seta-react/src/api/embeddings/embedding.ts
+++ b/seta-react/src/api/embeddings/embedding.ts
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import type { AxiosRequestConfig } from 'axios'
 
+import { environment } from '~/environments/environment'
+
 import api from '../api'
 import type { EmbeddingsResponse } from '../types/embeddings-types'
 
 const EMBEDDINGS_API_PATH = '/compute_embeddings'
+
+const axiosConfig: AxiosRequestConfig = {
+  baseURL: environment.nlpApiRoot
+}
 
 export const queryKey = {
   root: 'embeddings',
@@ -19,7 +25,14 @@ export const getEmbeddings = async (
     return { emb_with_chunk_text: [{ vector: [], chunk: 0, version: '', text: '' }] }
   }
 
-  const { data } = await api.post<EmbeddingsResponse>(`${EMBEDDINGS_API_PATH}`, { text }, config)
+  const { data } = await api.post<EmbeddingsResponse>(
+    EMBEDDINGS_API_PATH,
+    { text },
+    {
+      ...axiosConfig,
+      ...config
+    }
+  )
 
   return data
 }

--- a/seta-react/src/api/embeddings/file-to-text.ts
+++ b/seta-react/src/api/embeddings/file-to-text.ts
@@ -1,40 +1,22 @@
-import { useQuery } from '@tanstack/react-query'
 import type { AxiosRequestConfig } from 'axios'
 
+import { environment } from '~/environments/environment'
+
 import api from '../api'
-import type { FileToTextResponse } from '../types/file-to-text.-types'
 
 const FILE_TO_TEXT_API_PATH = '/file_to_text'
 
-export const queryKey = {
-  root: 'file_to_text',
-  file: (file?: FormData) => [queryKey.root, file]
+const axiosConfig: AxiosRequestConfig = {
+  baseURL: environment.nlpApiRoot
 }
-
-const getFileToText = async (
-  file?: FormData,
-  config?: AxiosRequestConfig
-): Promise<FileToTextResponse> => {
-  if (!file) {
-    return { text: '' }
-  }
-
-  const { data } = await api.post<FileToTextResponse>(`${FILE_TO_TEXT_API_PATH}`, file, config)
-
-  return {
-    text: data.text
-  }
-}
-
-export const useFileToText = (file?: FormData) =>
-  useQuery({ queryKey: queryKey.file(file), queryFn: () => getFileToText(file) })
 
 const retrieveText = async (file: File, config?: AxiosRequestConfig) => {
   const formData = new FormData()
 
   formData.append('file', file)
 
-  const { data } = await api.post<FileToTextResponse>(`${FILE_TO_TEXT_API_PATH}`, formData, {
+  const { data } = await api.post<string>(FILE_TO_TEXT_API_PATH, formData, {
+    ...axiosConfig,
     ...config,
     headers: {
       ...config?.headers,
@@ -42,41 +24,15 @@ const retrieveText = async (file: File, config?: AxiosRequestConfig) => {
     }
   })
 
-  return data.text
+  return data
 }
 
 export const getTextFromFile = async (file?: File, config?: AxiosRequestConfig) => {
   if (!file) {
-    return { text: '' }
+    return ''
   }
 
   const text = await retrieveText(file, config)
 
-  return {
-    text
-  }
-}
-
-export const getTextFromFiles = async (files?: File[], config?: AxiosRequestConfig) => {
-  if (!files) {
-    return { text: '' }
-  }
-
-  const textValues: string[] = []
-
-  for (const file of files) {
-    const text = await retrieveText(file, config)
-
-    textValues.push(
-      text
-        .split('\n')
-        .filter(Boolean)
-        .map(value => `"${value}"`)
-        .join(' ')
-    )
-  }
-
-  return {
-    text: textValues.join(' ')
-  }
+  return text
 }

--- a/seta-react/src/environments/environment.ts
+++ b/seta-react/src/environments/environment.ts
@@ -6,10 +6,9 @@ export const environment = {
   _regex: new RegExp(`_`, `g`),
   baseFlaskBackendUrl: 'http://localhost:8080',
   loginTokenExpiryInterval: 60, // In minutes
-  api_target_path: `/seta-api/api/v1/`,
-  community_api_target_path: `/seta-ui/api/v1/`,
+  searchApiRoot: `/seta-search/api/v1`,
+  nlpApiRoot: `/seta-nlp`,
   token_key: 'csrf_access_token',
   refreshtoken_key: 'csrf_refresh_token',
-  COMMUNITIES_API_PATH: '/communities',
   EU_Analytics_Site_ID: 'b240c41b-yyyyy-40af-96ef-xxxxxxxx'
 }

--- a/seta-react/src/libs/axios.ts
+++ b/seta-react/src/libs/axios.ts
@@ -7,7 +7,7 @@ import errorInterceptor from '~/libs/axios-error-interceptor'
 import { logResponse } from '~/libs/axios-logger'
 import { paramsSerializer } from '~/utils/api-utils'
 
-const API_ROOT = environment.api_target_path.replace(/\/+$/, '')
+const API_ROOT = environment.searchApiRoot
 
 export const axiosConfig: AxiosRequestConfig = {
   baseURL: API_ROOT,


### PR DESCRIPTION
This PR splits the API calls between `seta-search` and `seta-nlp`, with the needed adjustments.

Also, some bits of dead code have been cleaned up.

Please note that `seta-api` was not removed form the Docker file.