### PR TITLE
[seta-react] Remove Taxonomies from documents list

### DIFF
--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/DocumentInfo.tsx
@@ -32,7 +32,6 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
     source,
     collection,
     date,
-    taxonomy,
     chunk_text,
     chunk_number
   } = document
@@ -51,7 +50,7 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
 
   const [titleHl, abstractHl] = useHighlightWords(queryTerms, title, abstract)
 
-  const hasDetails = !!taxonomy?.length || !!chunk_text
+  const hasDetails = !!chunk_text
 
   const scorePercent = score.toLocaleString(undefined, {
     style: 'percent',
@@ -102,7 +101,6 @@ const DocumentInfo = ({ document, queryTerms }: Props) => {
       css={S.details}
       documentId={document_id}
       documentTitle={title}
-      taxonomy={taxonomy}
       chunkText={chunk_text}
       chunkNumber={chunk_number}
       queryTerms={queryTerms}

--- a/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
+++ b/seta-react/src/pages/SearchPageNew/components/documents/DocumentInfo/components/DocumentDetails/DocumentDetails.tsx
@@ -1,15 +1,12 @@
 import { Stack } from '@mantine/core'
 
 import type { ClassNameProp } from '~/types/children-props'
-import type { Taxonomy } from '~/types/search/documents'
 
 import ChunkPreview from '../ChunkPreview'
-import TaxonomyInfo from '../TaxonomyInfo'
 
 type Props = ClassNameProp & {
   documentTitle: string
   documentId: string
-  taxonomy: Taxonomy[] | null
   chunkText: string | null
   chunkNumber: number
   queryTerms?: string[]
@@ -19,14 +16,11 @@ const DocumentDetails = ({
   className,
   documentId,
   documentTitle,
-  taxonomy,
   chunkText,
   chunkNumber,
   queryTerms
 }: Props) => {
-  const hasTaxonomy = !!taxonomy?.length
-
-  if (!hasTaxonomy && !chunkText) {
+  if (!chunkText) {
     return null
   }
 
@@ -38,7 +32,8 @@ const DocumentDetails = ({
 
   return (
     <Stack spacing="sm" className={className}>
-      {hasTaxonomy && <TaxonomyInfo taxonomy={taxonomy} documentTitle={documentTitle} />}
+      {/* TODO: Add back in with flat list Taxonomies */}
+      {/* {hasTaxonomy && <TaxonomyInfo taxonomy={taxonomy} documentTitle={documentTitle} />} */}
 
       {chunkText && <ChunkPreview text={chunkText} queryTerms={queryTerms} {...chunkMeta} />}
     </Stack>


### PR DESCRIPTION
This PR (temporarily) removes the Taxonomies section from the documents list on the Search results.